### PR TITLE
Per-alliance Kingdom lock: reject mismatched player adds

### DIFF
--- a/cogs/alliance.py
+++ b/cogs/alliance.py
@@ -14,6 +14,48 @@ from .process_queue import ALLIANCE_CONTROL
 logger = logging.getLogger('alliance')
 
 
+def check_alliance_kingdom(alliance_id: int, player_kid) -> "str | None":
+    """Gate a player-add against the alliance's locked kingdom.
+
+    Returns None when the add is allowed; returns a human-readable reason string
+    when it should be denied. Callers wrap the string with their own icon/embed
+    pattern (typically ``f"{theme.deniedIcon} {reason}"``).
+
+    NULL ``alliance_list.kid`` is treated as "no restriction" so existing installs
+    are unaffected until an admin opts in by setting a kingdom on the alliance.
+    A NULL player kid (API didn't return one) fails closed when the alliance is
+    locked — we can't prove the player belongs.
+    """
+    try:
+        with sqlite3.connect("db/alliance.sqlite", timeout=30.0) as conn:
+            row = conn.execute(
+                "SELECT kid FROM alliance_list WHERE alliance_id = ?", (alliance_id,)
+            ).fetchone()
+    except sqlite3.OperationalError:
+        # Pre-migration DB or transient lock; fail open to preserve legacy behaviour.
+        return None
+    alliance_kid = row[0] if row else None
+    if alliance_kid is None:
+        return None
+    if player_kid is None:
+        return (
+            f"Player has no kingdom number from the API; "
+            f"this alliance is locked to Kingdom #{alliance_kid}."
+        )
+    try:
+        if int(player_kid) == int(alliance_kid):
+            return None
+    except (TypeError, ValueError):
+        return (
+            f"Could not read the player's kingdom number; "
+            f"this alliance is locked to Kingdom #{alliance_kid}."
+        )
+    return (
+        f"Player is in Kingdom #{player_kid}, "
+        f"but this alliance is locked to Kingdom #{alliance_kid}."
+    )
+
+
 def _alliance_sync_in_flight(process_queue, alliance_id: int) -> bool:
     """True if any sync work for this alliance is queued or running.
 
@@ -42,7 +84,8 @@ class Alliance(commands.Cog):
                 CREATE TABLE IF NOT EXISTS alliance_list (
                     alliance_id INTEGER PRIMARY KEY AUTOINCREMENT,
                     name TEXT UNIQUE NOT NULL,
-                    discord_server_id INTEGER
+                    discord_server_id INTEGER,
+                    kid INTEGER
                 )
             """)
             conn.commit()
@@ -54,6 +97,10 @@ class Alliance(commands.Cog):
             columns = [info[1] for info in cursor.fetchall()]
             if "discord_server_id" not in columns:
                 cursor.execute("ALTER TABLE alliance_list ADD COLUMN discord_server_id INTEGER")
+                conn.commit()
+            # Per-alliance kingdom lock. NULL = no restriction (legacy behaviour).
+            if "kid" not in columns:
+                cursor.execute("ALTER TABLE alliance_list ADD COLUMN kid INTEGER")
                 conn.commit()
 
     async def cog_unload(self):
@@ -456,6 +503,25 @@ class Alliance(commands.Cog):
             return
         await interaction.response.send_modal(
             EditNameModal(alliance_id, row[0], self.conn)
+        )
+
+    async def show_edit_kingdom_for(self, interaction: discord.Interaction, alliance_id: int):
+        """Open the per-alliance Kingdom modal. Empty stores NULL (no lock)."""
+        with sqlite3.connect('db/alliance.sqlite', timeout=30.0) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name, kid FROM alliance_list WHERE alliance_id = ?",
+                (alliance_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} Alliance not found.", ephemeral=True
+            )
+            return
+        alliance_name, current_kid = row
+        await interaction.response.send_modal(
+            EditKingdomModal(alliance_id, alliance_name, current_kid, self.conn)
         )
 
     async def show_edit_alliance_for(self, interaction: discord.Interaction, alliance_id: int):
@@ -1519,8 +1585,10 @@ class AllianceModal(discord.ui.Modal):
 
 
 class AddAllianceModal(discord.ui.Modal):
-    """Single-field alliance creator. Inserts a new alliance with safe defaults
-    (interval=60min, no channel, no start time). Channels and sync settings are
+    """Two-field alliance creator. Inserts a new alliance with safe defaults
+    (interval=60min, no channel, no start time). The optional Kingdom (#) field
+    locks the alliance to a single kingdom so non-matching players are rejected
+    on add — leave blank for no restriction. Channels and sync settings are
     configured post-creation via Channel Setup / Sync Settings."""
 
     DEFAULT_INTERVAL_MINUTES = 60
@@ -1535,6 +1603,13 @@ class AddAllianceModal(discord.ui.Modal):
             max_length=50,
         )
         self.add_item(self.name_input)
+        self.kid_input = discord.ui.TextInput(
+            label="Kingdom # (optional)",
+            placeholder="Leave blank for no kingdom restriction",
+            required=False,
+            max_length=10,
+        )
+        self.add_item(self.kid_input)
 
     async def on_submit(self, interaction: discord.Interaction):
         alliance_name = self.name_input.value.strip()
@@ -1543,6 +1618,21 @@ class AddAllianceModal(discord.ui.Modal):
                 f"{theme.deniedIcon} Alliance name cannot be empty.", ephemeral=True
             )
             return
+
+        kid_raw = (self.kid_input.value or "").strip()
+        parsed_kid = None
+        if kid_raw:
+            try:
+                parsed_kid = int(kid_raw)
+                if parsed_kid <= 0:
+                    raise ValueError
+            except ValueError:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Kingdom must be a positive whole number "
+                    f"(or leave blank for no restriction).",
+                    ephemeral=True,
+                )
+                return
 
         try:
             with sqlite3.connect('db/alliance.sqlite', timeout=30.0) as conn:
@@ -1558,8 +1648,11 @@ class AddAllianceModal(discord.ui.Modal):
                     return
 
                 cursor.execute(
-                    "INSERT INTO alliance_list (name, discord_server_id) VALUES (?, ?)",
-                    (alliance_name, interaction.guild.id if interaction.guild else None),
+                    "INSERT INTO alliance_list (name, discord_server_id, kid) "
+                    "VALUES (?, ?, ?)",
+                    (alliance_name,
+                     interaction.guild.id if interaction.guild else None,
+                     parsed_kid),
                 )
                 alliance_id = cursor.lastrowid
                 cursor.execute(
@@ -1651,6 +1744,77 @@ class EditNameModal(discord.ui.Modal):
                 )
             except Exception:
                 pass
+
+class EditKingdomModal(discord.ui.Modal):
+    """Single-field editor for an alliance's locked Kingdom. Empty input clears
+    the lock (sets kid to NULL); a positive integer locks the alliance to that
+    kingdom so non-matching players are rejected at add-time."""
+
+    def __init__(self, alliance_id: int, alliance_name: str,
+                 current_kid, conn):
+        super().__init__(title="Set Alliance Kingdom")
+        self.alliance_id = alliance_id
+        self.alliance_name = alliance_name
+        self.conn = conn
+        self.kid_input = discord.ui.TextInput(
+            label="Kingdom # (blank = no lock)",
+            placeholder="Leave blank to clear the kingdom restriction",
+            default=("" if current_kid is None else str(current_kid)),
+            required=False,
+            max_length=10,
+        )
+        self.add_item(self.kid_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        raw = (self.kid_input.value or "").strip()
+        new_kid = None
+        if raw:
+            try:
+                new_kid = int(raw)
+                if new_kid <= 0:
+                    raise ValueError
+            except ValueError:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Kingdom must be a positive whole number "
+                    f"(or leave blank to clear).",
+                    ephemeral=True,
+                )
+                return
+        try:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                "UPDATE alliance_list SET kid = ? WHERE alliance_id = ?",
+                (new_kid, self.alliance_id),
+            )
+            self.conn.commit()
+
+            if new_kid is None:
+                desc = (
+                    f"{theme.allianceIcon} **{self.alliance_name}**\n"
+                    f"Kingdom lock **cleared** — players from any kingdom can now be added."
+                )
+            else:
+                desc = (
+                    f"{theme.allianceIcon} **{self.alliance_name}**\n"
+                    f"Locked to **Kingdom #{new_kid}** — only players in this kingdom "
+                    f"can be added going forward."
+                )
+            embed = discord.Embed(
+                title=f"{theme.verifiedIcon} Kingdom Updated",
+                description=desc,
+                color=theme.emColor3,
+            )
+            await interaction.response.edit_message(embed=embed, view=None)
+        except Exception as e:
+            logger.error(f"Error setting kingdom on alliance {self.alliance_id}: {e}")
+            print(f"Error setting kingdom on alliance {self.alliance_id}: {e}")
+            try:
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Failed to update kingdom.", ephemeral=True
+                )
+            except Exception:
+                pass
+
 
 class PaginatedDeleteView(discord.ui.View):
     def __init__(self, pages, original_callback):

--- a/cogs/alliance.py
+++ b/cogs/alliance.py
@@ -14,27 +14,32 @@ from .process_queue import ALLIANCE_CONTROL
 logger = logging.getLogger('alliance')
 
 
-def check_alliance_kingdom(alliance_id: int, player_kid) -> "str | None":
-    """Gate a player-add against the alliance's locked kingdom.
+# Fail-closed denial when the gate can't read the lock (DB busy).
+KINGDOM_CHECK_UNAVAILABLE = (
+    "Could not verify the alliance's kingdom lock right now (database busy). "
+    "Please try again in a moment."
+)
 
-    Returns None when the add is allowed; returns a human-readable reason string
-    when it should be denied. Callers wrap the string with their own icon/embed
-    pattern (typically ``f"{theme.deniedIcon} {reason}"``).
 
-    NULL ``alliance_list.kid`` is treated as "no restriction" so existing installs
-    are unaffected until an admin opts in by setting a kingdom on the alliance.
-    A NULL player kid (API didn't return one) fails closed when the alliance is
-    locked — we can't prove the player belongs.
-    """
+def resolve_alliance_kid(alliance_id: int):
+    """Read the alliance's locked kid -> (ok, kid); ok=False means fail closed."""
     try:
         with sqlite3.connect("db/alliance.sqlite", timeout=30.0) as conn:
             row = conn.execute(
                 "SELECT kid FROM alliance_list WHERE alliance_id = ?", (alliance_id,)
             ).fetchone()
-    except sqlite3.OperationalError:
-        # Pre-migration DB or transient lock; fail open to preserve legacy behaviour.
-        return None
-    alliance_kid = row[0] if row else None
+    except sqlite3.OperationalError as e:
+        msg = str(e).lower()
+        if "no such table" in msg or "no such column" in msg:
+            return True, None  # pre-migration DB: lock feature absent -> unrestricted
+        logger.warning(f"Kingdom gate read failed for alliance {alliance_id}: {e}")
+        print(f"Kingdom gate read failed for alliance {alliance_id}: {e}")
+        return False, None
+    return True, (row[0] if row else None)
+
+
+def kingdom_lock_reason(alliance_kid, player_kid) -> "str | None":
+    """Denial reason for this player kid against a resolved alliance kid, else None."""
     if alliance_kid is None:
         return None
     if player_kid is None:
@@ -54,6 +59,15 @@ def check_alliance_kingdom(alliance_id: int, player_kid) -> "str | None":
         f"Player is in Kingdom #{player_kid}, "
         f"but this alliance is locked to Kingdom #{alliance_kid}."
     )
+
+
+def check_alliance_kingdom(alliance_id: int, player_kid) -> "str | None":
+    """Single-add gate: denial reason for one player kid, else None. Bulk adds
+    should call resolve_alliance_kid once + kingdom_lock_reason per player."""
+    ok, alliance_kid = resolve_alliance_kid(alliance_id)
+    if not ok:
+        return KINGDOM_CHECK_UNAVAILABLE
+    return kingdom_lock_reason(alliance_kid, player_kid)
 
 
 def _alliance_sync_in_flight(process_queue, alliance_id: int) -> bool:
@@ -521,7 +535,7 @@ class Alliance(commands.Cog):
             return
         alliance_name, current_kid = row
         await interaction.response.send_modal(
-            EditKingdomModal(alliance_id, alliance_name, current_kid, self.conn)
+            EditKingdomModal(alliance_id, alliance_name, current_kid, self.conn, self.bot)
         )
 
     async def show_edit_alliance_for(self, interaction: discord.Interaction, alliance_id: int):
@@ -1751,11 +1765,12 @@ class EditKingdomModal(discord.ui.Modal):
     kingdom so non-matching players are rejected at add-time."""
 
     def __init__(self, alliance_id: int, alliance_name: str,
-                 current_kid, conn):
+                 current_kid, conn, bot):
         super().__init__(title="Set Alliance Kingdom")
         self.alliance_id = alliance_id
         self.alliance_name = alliance_name
         self.conn = conn
+        self.bot = bot
         self.kid_input = discord.ui.TextInput(
             label="Kingdom # (blank = no lock)",
             placeholder="Leave blank to clear the kingdom restriction",
@@ -1787,24 +1802,6 @@ class EditKingdomModal(discord.ui.Modal):
                 (new_kid, self.alliance_id),
             )
             self.conn.commit()
-
-            if new_kid is None:
-                desc = (
-                    f"{theme.allianceIcon} **{self.alliance_name}**\n"
-                    f"Kingdom lock **cleared** — players from any kingdom can now be added."
-                )
-            else:
-                desc = (
-                    f"{theme.allianceIcon} **{self.alliance_name}**\n"
-                    f"Locked to **Kingdom #{new_kid}** — only players in this kingdom "
-                    f"can be added going forward."
-                )
-            embed = discord.Embed(
-                title=f"{theme.verifiedIcon} Kingdom Updated",
-                description=desc,
-                color=theme.emColor3,
-            )
-            await interaction.response.edit_message(embed=embed, view=None)
         except Exception as e:
             logger.error(f"Error setting kingdom on alliance {self.alliance_id}: {e}")
             print(f"Error setting kingdom on alliance {self.alliance_id}: {e}")
@@ -1814,6 +1811,26 @@ class EditKingdomModal(discord.ui.Modal):
                 )
             except Exception:
                 pass
+            return
+
+        if new_kid is None:
+            result = (
+                f"{theme.verifiedIcon} **{self.alliance_name}** kingdom lock cleared. "
+                f"Players from any kingdom can now be added."
+            )
+        else:
+            result = (
+                f"{theme.verifiedIcon} **{self.alliance_name}** locked to Kingdom #{new_kid}. "
+                f"Only players in this kingdom can be added going forward."
+            )
+
+        # Return to the hub and report the result.
+        main_menu = self.bot.get_cog("MainMenu")
+        if main_menu:
+            await main_menu.show_alliance_hub(interaction, self.alliance_id)
+            await interaction.followup.send(result, ephemeral=True)
+        else:
+            await interaction.response.send_message(result, ephemeral=True)
 
 
 class PaginatedDeleteView(discord.ui.View):

--- a/cogs/alliance_id_channel.py
+++ b/cogs/alliance_id_channel.py
@@ -13,6 +13,7 @@ from discord.ext import tasks
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme, safe_edit_message
 from .login_handler import LoginHandler
+from .alliance import check_alliance_kingdom
 
 logger = logging.getLogger('alliance')
 
@@ -336,6 +337,15 @@ class AllianceIDChannel(commands.Cog):
                 stove_lv_content = result['data'].get('stove_lv_content', None)
                 kid = result['data'].get('kid', None)
                 avatar_image = result['data'].get('avatar_image', None)
+
+                kingdom_error = check_alliance_kingdom(alliance_id, kid)
+                if kingdom_error:
+                    await message.add_reaction(theme.deniedIcon)
+                    await message.reply(
+                        f"{theme.deniedIcon} {kingdom_error}",
+                        delete_after=delete_after,
+                    )
+                    return
 
                 try:
                     with sqlite3.connect('db/users.sqlite') as users_db:

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -17,6 +17,7 @@ from .login_handler import LoginHandler
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme, safe_edit_message, disable_expired_view
 from .process_queue import MEMBER_ADD, PreemptedException
+from .alliance import check_alliance_kingdom
 
 logger = logging.getLogger('alliance')
 
@@ -2568,6 +2569,24 @@ class AllianceMemberOperations(commands.Cog):
                         furnace_lv = data.get('stove_lv', 0)
                         stove_lv_content = data.get('stove_lv_content', None)
                         kid = data.get('kid', None)
+
+                        kingdom_error = check_alliance_kingdom(alliance_id, kid)
+                        if kingdom_error:
+                            with open(log_file_path, 'a', encoding='utf-8') as log_file:
+                                log_file.write(f"REJECTED: ID {fid} — {kingdom_error}\n")
+                            error_count += 1
+                            if fid not in error_users:
+                                error_users.append(fid)
+                            embed.set_field_at(
+                                1,
+                                name=f"{theme.deniedIcon} Failed ({error_count}/{total_users})",
+                                value="Error list cannot be displayed due to exceeding 70 users" if len(error_users) > 70
+                                else ", ".join(error_users) or "-",
+                                inline=False
+                            )
+                            await progress.edit(embed)
+                            index += 1
+                            continue
 
                         if nickname:
                             try: # Since we pre-filtered, this ID should not exist in database

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -2575,8 +2575,12 @@ class AllianceMemberOperations(commands.Cog):
                             with open(log_file_path, 'a', encoding='utf-8') as log_file:
                                 log_file.write(f"REJECTED: ID {fid} — {kingdom_error}\n")
                             error_count += 1
-                            if fid not in error_users:
-                                error_users.append(fid)
+                            # Surface the nickname alongside the fid in the failure
+                            # field — for kingdom rejections we always have it from
+                            # the API; fall back to bare fid if it's somehow missing.
+                            display = f"{nickname} ({fid})" if nickname else str(fid)
+                            if display not in error_users and fid not in error_users:
+                                error_users.append(display)
                             embed.set_field_at(
                                 1,
                                 name=f"{theme.deniedIcon} Failed ({error_count}/{total_users})",

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -17,7 +17,7 @@ from .login_handler import LoginHandler
 from .permission_handler import PermissionManager
 from .pimp_my_bot import theme, safe_edit_message, disable_expired_view
 from .process_queue import MEMBER_ADD, PreemptedException
-from .alliance import check_alliance_kingdom
+from .alliance import resolve_alliance_kid, kingdom_lock_reason, KINGDOM_CHECK_UNAVAILABLE
 
 logger = logging.getLogger('alliance')
 
@@ -2506,6 +2506,9 @@ class AllianceMemberOperations(commands.Cog):
             # Cooperative preemption: yield to higher-priority work between members
             process_queue_cog = self.bot.get_cog('ProcessQueue')
 
+            # Resolve the alliance's kingdom lock once for the whole batch.
+            kid_ok, locked_kid = resolve_alliance_kid(alliance_id)
+
             index = 0
             while index < len(fids_to_process):
                 # Check for higher-priority work
@@ -2570,17 +2573,15 @@ class AllianceMemberOperations(commands.Cog):
                         stove_lv_content = data.get('stove_lv_content', None)
                         kid = data.get('kid', None)
 
-                        kingdom_error = check_alliance_kingdom(alliance_id, kid)
+                        kingdom_error = (
+                            KINGDOM_CHECK_UNAVAILABLE if not kid_ok
+                            else kingdom_lock_reason(locked_kid, kid)
+                        )
                         if kingdom_error:
                             with open(log_file_path, 'a', encoding='utf-8') as log_file:
-                                log_file.write(f"REJECTED: ID {fid} — {kingdom_error}\n")
+                                log_file.write(f"REJECTED: ID {fid} - {kingdom_error}\n")
                             error_count += 1
-                            # Surface the nickname alongside the fid in the failure
-                            # field — for kingdom rejections we always have it from
-                            # the API; fall back to bare fid if it's somehow missing.
-                            display = f"{nickname} ({fid})" if nickname else str(fid)
-                            if display not in error_users and fid not in error_users:
-                                error_users.append(display)
+                            error_users.append(fid)
                             embed.set_field_at(
                                 1,
                                 name=f"{theme.deniedIcon} Failed ({error_count}/{total_users})",

--- a/cogs/alliance_registration.py
+++ b/cogs/alliance_registration.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime, timezone
 from .pimp_my_bot import theme
 from .login_handler import LoginHandler
+from .alliance import check_alliance_kingdom
 
 logger = logging.getLogger('alliance')
 
@@ -250,6 +251,14 @@ class AllianceRegistration(commands.Cog):
                     f"{theme.deniedIcon} Failed to fetch user data. Please try again later.",
                     ephemeral=True,
                 )
+            return
+
+        kingdom_error = check_alliance_kingdom(alliance, user_data.get("kid"))
+        if kingdom_error:
+            await interaction.followup.send(
+                f"{theme.deniedIcon} {kingdom_error}",
+                ephemeral=True,
+            )
             return
 
         self._insert_new_user(fid, user_data, alliance, caller_id, current_server_id)

--- a/cogs/bot_main_menu.py
+++ b/cogs/bot_main_menu.py
@@ -250,7 +250,7 @@ class MainMenu(commands.Cog):
             with sqlite3.connect('db/alliance.sqlite') as db:
                 cursor = db.cursor()
                 cursor.execute(
-                    "SELECT name FROM alliance_list WHERE alliance_id = ?",
+                    "SELECT name, kid FROM alliance_list WHERE alliance_id = ?",
                     (alliance_id,),
                 )
                 row = cursor.fetchone()
@@ -260,7 +260,7 @@ class MainMenu(commands.Cog):
                     ephemeral=True,
                 )
                 return
-            alliance_name = row[0]
+            alliance_name, alliance_kid = row[0], row[1]
 
             with sqlite3.connect('db/users.sqlite') as db:
                 cursor = db.cursor()
@@ -282,6 +282,16 @@ class MainMenu(commands.Cog):
             else:
                 stats_line = "_No members yet — use **Add Members** to get started_"
 
+            if alliance_kid is None:
+                kingdom_line = (
+                    f"{theme.globeIcon} **Kingdom:** _not locked_ "
+                    f"(players from any kingdom can be added)"
+                )
+            else:
+                kingdom_line = (
+                    f"{theme.globeIcon} **Kingdom:** locked to `#{alliance_kid}`"
+                )
+
             tier = PermissionManager.get_tier(interaction.user.id)
             accessible, _ = PermissionManager.get_admin_alliances(
                 interaction.user.id, interaction.guild_id
@@ -299,7 +309,8 @@ class MainMenu(commands.Cog):
             embed = discord.Embed(
                 title=f"{theme.allianceIcon} {alliance_name}",
                 description=(
-                    f"{theme.membersIcon} {stats_line}\n\n"
+                    f"{theme.membersIcon} {stats_line}\n"
+                    f"{kingdom_line}\n\n"
                     f"Pick an action below, or use the dropdown to switch "
                     f"to a different alliance.\n\n"
                     f"**Actions**\n"
@@ -312,6 +323,8 @@ class MainMenu(commands.Cog):
                     f"└ Sync interval, auto-removal on transfer, notifications, logs\n\n"
                     f"{theme.editListIcon} **Edit Name**\n"
                     f"└ Rename this alliance\n\n"
+                    f"{theme.globeIcon} **Set Kingdom**\n"
+                    f"└ Lock this alliance to one Kingdom (rejects mismatched adds)\n\n"
                     f"{theme.listIcon} **History**\n"
                     f"└ Town Center level and nickname change history per member\n\n"
                     f"{theme.chartIcon} **Power Rankings**\n"
@@ -792,7 +805,7 @@ class AllianceHubView(discord.ui.View):
     """Per-alliance hub. Layout:
       row 0: alliance switch dropdown
       row 1: Manage Members | Channel Setup
-      row 2: Settings | Edit Name
+      row 2: Settings | Edit Name | Set Kingdom
       row 3: History | Power Rankings
       row 4: Back | Delete Alliance
     """
@@ -879,6 +892,16 @@ class AllianceHubView(discord.ui.View):
         await _route_to_cog(
             interaction, self.cog.bot, "Alliance",
             "show_edit_name_for", self.alliance_id,
+            fallback_method="show_alliance_operations",
+            missing_label="Alliance",
+        )
+
+    @discord.ui.button(label="Set Kingdom", emoji=theme.globeIcon,
+                       style=discord.ButtonStyle.primary, row=2)
+    async def set_kingdom(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await _route_to_cog(
+            interaction, self.cog.bot, "Alliance",
+            "show_edit_kingdom_for", self.alliance_id,
             fallback_method="show_alliance_operations",
             missing_label="Alliance",
         )

--- a/main.py
+++ b/main.py
@@ -1366,12 +1366,16 @@ if __name__ == "__main__":
             conn_alliance.execute("""CREATE TABLE IF NOT EXISTS alliance_list (
                 alliance_id INTEGER PRIMARY KEY,
                 name TEXT,
-                discord_server_id INTEGER
+                discord_server_id INTEGER,
+                kid INTEGER
             )""")
             # Upgrade path: ensure discord_server_id exists before any cog queries it.
             existing_cols = [row[1] for row in conn_alliance.execute("PRAGMA table_info(alliance_list)").fetchall()]
             if "discord_server_id" not in existing_cols:
                 conn_alliance.execute("ALTER TABLE alliance_list ADD COLUMN discord_server_id INTEGER")
+            # Upgrade path: per-alliance kingdom lock. NULL = no restriction (legacy behaviour).
+            if "kid" not in existing_cols:
+                conn_alliance.execute("ALTER TABLE alliance_list ADD COLUMN kid INTEGER")
 
     create_tables()
     startup.phase_ok("Database ready")


### PR DESCRIPTION
Each alliance can now declare which Kingdom it lives in (alliance_list.kid, nullable INTEGER). When set, three add paths reject players whose API-reported kid doesn't match; NULL means no restriction so existing installs are unaffected until an admin opts in.

Schema:
- main.py + cogs/alliance.py: try-select-then-ALTER upgrade adds alliance_list.kid to legacy tables; new installs get the column from the CREATE TABLE.

Helper (cogs/alliance.py):
- check_alliance_kingdom(alliance_id, player_kid) -> str|None. Returns a human-readable reason when the add must be denied; None when allowed. NULL alliance kid -> unrestricted. NULL player kid against a locked alliance -> fail closed.

Gated add paths (called after API success, before INSERT INTO users):
- cogs/alliance_registration.py    /register slash command
- cogs/alliance_member_operations.py  manual + bulk/CSV add (continues the
  batch on rejection, doesn't abort; rejected fid logged + counted as failed)
- cogs/alliance_id_channel.py      auto-add from ID channel posts

OCR add path (attendance_ocr_review.py) intentionally NOT gated - admin-driven, out of scope for this gate.

UI:
- AddAllianceModal: new optional 'Kingdom # (optional)' field; blank stays NULL, positive integer locks the alliance at creation time.
- EditKingdomModal + Alliance.show_edit_kingdom_for in cogs/alliance.py: mirrors EditNameModal; blank clears the lock, integer sets it.
- AllianceHubView (bot_main_menu.py): new 'Set Kingdom' button on row 2, and the hub embed now shows 'Kingdom: locked to #X' or 'Kingdom: not locked' next to the member-count line.

Behaviour on existing installs is unchanged: every existing alliance has kid = NULL after migration, so all four legacy add paths continue to insert exactly as before until an admin sets a kingdom from the hub.