### PR TITLE
Redemption History, Summary and various gift code fixes and enhancements

### DIFF
--- a/cogs/gift_channels.py
+++ b/cogs/gift_channels.py
@@ -928,7 +928,7 @@ async def channel_history_scan(cog, interaction: discord.Interaction):
                 if existing_invalid > 0:
                     results_text += f"{theme.deniedIcon} Previously Invalid: {existing_invalid}\n"
                 if existing_pending > 0:
-                    results_text += f"{theme.warnIcon} Pending Validation: {existing_pending}\n"
+                    results_text += f"{theme.warnIcon} Validating: {existing_pending}\n"
 
                 results_text += f"\n{theme.editListIcon} **Note:** A detailed summary has been posted in #{channel.name}"
             else:

--- a/cogs/gift_operations.py
+++ b/cogs/gift_operations.py
@@ -100,7 +100,7 @@ class GiftOperations(commands.Cog):
         except sqlite3.OperationalError:
             pass
 
-        # WOS API URLs and Key
+        # Kingshot API URLs and Key
         self.wos_player_info_url = "https://kingshot-giftcode.centurygame.com/api/player"
         self.wos_giftcode_url = "https://kingshot-giftcode.centurygame.com/api/gift_code"
         self.wos_giftcode_redemption_url = "https://kingshot-giftcode.centurygame.com"
@@ -305,6 +305,8 @@ class GiftOperations(commands.Cog):
                 f"└ View all active, valid codes\n\n"
                 f"{theme.targetIcon} **Redeem Gift Code**\n"
                 f"└ Redeem gift code(s) for one or more alliances\n\n"
+                f"{theme.archiveIcon} **Redemption History**\n"
+                f"└ See which accounts redeemed, already had, or failed a code\n\n"
                 f"{theme.settingsIcon} **Settings**\n"
                 f"└ Set up a gift code channel, configure auto redemption, and more...\n\n"
                 f"{theme.deniedIcon} **Delete Gift Code**\n"
@@ -318,8 +320,8 @@ class GiftOperations(commands.Cog):
 
     # ── Delegation to gift_redemption ─────────────────────────────────
 
-    async def validate_gift_code_immediately(self, giftcode, source="unknown"):
-        return await gift_redemption.validate_gift_code_immediately(self, giftcode, source)
+    async def validate_gift_code_immediately(self, giftcode, source="unknown", force=False):
+        return await gift_redemption.validate_gift_code_immediately(self, giftcode, source, force)
 
     def encode_data(self, data):
         return gift_redemption.encode_data(self, data)
@@ -399,8 +401,14 @@ class GiftOperations(commands.Cog):
     async def verify_test_fid(self, fid):
         return await gift_settings.verify_test_fid(self, fid)
 
+    async def update_test_fid(self, new_fid):
+        return await gift_settings.update_test_fid(self, new_fid)
+
     def get_test_fid(self):
         return gift_settings.get_test_fid(self)
+
+    def clear_test_fid(self):
+        return gift_settings.clear_test_fid(self)
 
     async def get_validation_fid(self):
         return await gift_settings.get_validation_fid(self)
@@ -408,8 +416,15 @@ class GiftOperations(commands.Cog):
     async def show_redemption_priority(self, interaction):
         return await gift_settings.show_redemption_priority(self, interaction)
 
+    async def show_redemption_summary(self, interaction):
+        return await gift_settings.show_redemption_summary(self, interaction)
+
     async def setup_giftcode_auto(self, interaction):
         return await gift_settings.setup_giftcode_auto(self, interaction)
+
+    async def show_redeem_results(self, interaction):
+        from .gift_redemption_results import show_redeem_results as _show
+        return await _show(self, interaction)
 
     # ── Delegation to gift_views ──────────────────────────────────────
 

--- a/cogs/gift_operationsapi.py
+++ b/cogs/gift_operationsapi.py
@@ -240,16 +240,21 @@ class GiftCodeAPI:
                             new_codes = []
                             for code, date_obj in valid_codes:
                                 formatted_date = date_obj.strftime("%Y-%m-%d")
-                                if code not in db_codes:
+                                prior = db_codes.get(code)
+                                if prior is None:
                                     try:
                                         # First add as pending
                                         self.cursor.execute(
                                             "INSERT OR IGNORE INTO gift_codes (giftcode, date, validation_status) VALUES (?, ?, ?)",
                                             (code, formatted_date, "pending")
                                         )
-                                        new_codes.append((code, formatted_date))
+                                        new_codes.append((code, formatted_date, False))
                                     except Exception as e:
                                         self.logger.exception(f"Error inserting new code {code}: {e}")
+                                elif prior[1] == 'invalid':
+                                    # API still distributing a code we hold invalid. Don't trust it -
+                                    # re-validate ourselves; only our own check can confirm a reactivation.
+                                    new_codes.append((code, formatted_date, True))
 
                             try:
                                 await self._safe_commit(self.conn, "new codes insertion")
@@ -261,72 +266,37 @@ class GiftCodeAPI:
                                     valid_codes_count = 0
                                     invalid_codes_count = 0
                                     
-                                    for code, formatted_date in new_codes:
+                                    for code, formatted_date, was_invalid in new_codes:
                                         try:
                                             # Get GiftOperations cog to validate
                                             gift_operations = self.bot.get_cog('GiftOperations')
                                             if gift_operations:
-                                                is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api")
+                                                is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api", force=was_invalid)
 
                                                 if is_valid is None:
-                                                    self.logger.warning(f"API code '{code}' validation inconclusive on first attempt: {validation_msg}. Retrying...")
-
-                                                    for retry_num in range(1, 4):
-                                                        await asyncio.sleep(5)
-                                                        self.logger.info(f"Retry {retry_num}/3 for code '{code}'")
-                                                        is_valid, validation_msg = await gift_operations.validate_gift_code_immediately(code, "api")
-
-                                                        if is_valid is not None:
-                                                            break
-
-                                                    if is_valid is None:
-                                                        self.logger.warning(f"API code '{code}' still inconclusive after 3 retries. Marking as pending.")
+                                                    # Inconclusive. Don't rapid-retry here - the spaced
+                                                    # re-validation chain below picks it up cleanly.
+                                                    self.logger.info(f"API code '{code}' not conclusively validated yet ({validation_msg}); scheduling spaced re-validation.")
 
                                                 if is_valid:
                                                     valid_codes_count += 1
                                                     self.logger.info(f"API code '{code}' validated successfully")
 
-                                                    # Check if this code was previously invalid (reactivation detection)
-                                                    is_reactivated = False
+                                                    # A code we held invalid that our OWN re-validation now confirms valid
+                                                    # is a genuine reactivation: clear old redemptions so members can claim again.
                                                     cleared_redemptions = 0
-
-                                                    try:
-                                                        self.cursor.execute(
-                                                            "SELECT validation_status FROM gift_codes WHERE giftcode = ?",
-                                                            (code,)
-                                                        )
-                                                        previous_status_row = self.cursor.fetchone()
-
-                                                        if previous_status_row and previous_status_row[0] == 'invalid':
-                                                            # This is a REACTIVATED code - clear all user redemption history
-                                                            self.logger.info(f"🔄 REACTIVATION DETECTED: Code '{code}' was invalid, now valid again")
-
-                                                            # Count existing redemptions before clearing
-                                                            self.cursor.execute(
-                                                                "SELECT COUNT(*) FROM user_giftcodes WHERE giftcode = ?",
-                                                                (code,)
-                                                            )
+                                                    if was_invalid:
+                                                        try:
+                                                            self.cursor.execute("SELECT COUNT(*) FROM user_giftcodes WHERE giftcode = ?", (code,))
                                                             count_row = self.cursor.fetchone()
                                                             cleared_redemptions = count_row[0] if count_row else 0
-
-                                                            # Clear all user redemption records for this code
-                                                            self.cursor.execute(
-                                                                "DELETE FROM user_giftcodes WHERE giftcode = ?",
-                                                                (code,)
-                                                            )
+                                                            self.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (code,))
                                                             await self._safe_commit(self.conn, f"clear redemption history for reactivated code {code}")
+                                                            self.logger.info(f"🔄 REACTIVATION: '{code}' re-validated valid; cleared {cleared_redemptions} old redemption records")
+                                                        except Exception as e:
+                                                            self.logger.error(f"Error clearing reactivation history for code '{code}': {e}")
 
-                                                            self.logger.info(f"✅ Cleared {cleared_redemptions} redemption records for reactivated code '{code}'")
-                                                            is_reactivated = True
-
-                                                    except Exception as e:
-                                                        self.logger.error(f"Error checking/clearing reactivation status for code '{code}': {e}")
-
-                                                    # Set validation status message
-                                                    if is_reactivated:
-                                                        validation_status = f"✅ Validated (🔄 REACTIVATED - {cleared_redemptions} redemptions cleared)"
-                                                    else:
-                                                        validation_status = "✅ Validated"
+                                                    validation_status = f"✅ Validated (🔄 Reactivated - {cleared_redemptions} cleared)" if was_invalid else "✅ Validated"
 
                                                     try:
                                                         await self._execute_with_retry(
@@ -350,7 +320,7 @@ class GiftCodeAPI:
                                                     auto_alliances = []
                                                 else:
                                                     self.logger.warning(f"API code '{code}' validation inconclusive after retries: {validation_msg}")
-                                                    validation_status = f"{theme.warnIcon} Pending"
+                                                    validation_status = f"{theme.warnIcon} Validating"
                                                     auto_alliances = []
                                                     # Re-test soon instead of waiting for the 2h loop.
                                                     gift_operations.schedule_revalidation(code, "api")
@@ -359,9 +329,13 @@ class GiftCodeAPI:
                                                 validation_status = f"{theme.deniedIcon} Error"
                                                 auto_alliances = []
 
+                                            # A code we already held invalid that didn't re-validate as valid isn't
+                                            # news (avoids re-notifying every sync when the API keeps distributing it).
+                                            notify = (not was_invalid) or (is_valid is True)
+
                                             self.settings_cursor.execute("SELECT id FROM admin WHERE is_initial = 1")
                                             admin_ids = self.settings_cursor.fetchall()
-                                            if admin_ids:
+                                            if notify and admin_ids:
                                                 embed_description = (
                                                     f"**Gift Code Details**\n"
                                                     f"{theme.upperDivider}\n"
@@ -370,12 +344,16 @@ class GiftCodeAPI:
                                                     f"{theme.listIcon} **Validation Status:** `{validation_status}`\n"
                                                     f"{theme.linkIcon} **Source:** `Retrieved from Bot API`\n"
                                                     f"{theme.alarmClockIcon} **Time:** <t:{int(datetime.now().timestamp())}:R>\n"
-                                                    f"{theme.refreshIcon} **Auto Alliance Count:** `{len(auto_alliances)}`\n"
                                                 )
 
-                                                if is_valid is None:
+                                                if is_valid:
+                                                    if auto_alliances:
+                                                        embed_description += f"{theme.refreshIcon} **Auto-redemption:** Queued for `{len(auto_alliances)}` Alliances\n"
+                                                    else:
+                                                        embed_description += f"{theme.refreshIcon} **Auto-redemption** is not enabled\n"
+                                                elif is_valid is None:
                                                     from . import gift_redemption
-                                                    embed_description += f"\n{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
+                                                    embed_description += f"{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
 
                                                 embed_description += f"{theme.lowerDivider}\n"
 
@@ -400,14 +378,23 @@ class GiftCodeAPI:
                                                 self.cursor.execute("SELECT DISTINCT channel_id FROM giftcode_channel")
                                                 gift_channels = self.cursor.fetchall()
 
-                                                if gift_channels:
+                                                if notify and gift_channels:
+                                                    channel_desc = (
+                                                        f"**Code:** `{code}`\n"
+                                                        f"**Status:** {validation_status}\n"
+                                                    )
+                                                    if is_valid:
+                                                        if auto_alliances:
+                                                            channel_desc += f"**Auto-redemption:** Queued for {len(auto_alliances)} Alliances"
+                                                        else:
+                                                            channel_desc += "**Auto-redemption** is not enabled"
+                                                    elif is_valid is None:
+                                                        channel_desc += "**Auto-redemption:** Runs automatically as soon as the code validates"
+                                                    else:
+                                                        channel_desc += "**Auto-redemption:** Not redeemed (code is invalid)"
                                                     channel_embed = discord.Embed(
                                                         title="🎁 New Gift Code Retrieved",
-                                                        description=(
-                                                            f"**Code:** `{code}`\n"
-                                                            f"**Status:** {validation_status}\n"
-                                                            f"**Auto-redemption:** {'Started' if auto_alliances else 'Disabled'}"
-                                                        ),
+                                                        description=channel_desc,
                                                         color=embed_color
                                                     )
                                                     channel_embed.set_footer(text="Retrieved via Gift Code Distribution API")

--- a/cogs/gift_redemption.py
+++ b/cogs/gift_redemption.py
@@ -71,13 +71,13 @@ async def enqueue_redemption(cog, giftcode, alliance_id, source='manual', batch_
 
 # Shown when a new code can't be confirmed yet; schedule_revalidation re-tests it within minutes.
 PENDING_REVALIDATION_NOTICE = (
-    "⏳ Auto-redemption pending - couldn't confirm the code yet. It'll be "
-    "automatically re-tested over the next few minutes; redemption starts as "
-    "soon as it validates. You can also trigger the redemption manually if needed."
+    "⏳ Not confirmed yet - re-checking automatically; it redeems as soon as it validates."
 )
 
-# Backoff (seconds) for re-testing an inconclusive new code: 1m, 2m, 5m, 15m, then the 2h loop.
-_REVALIDATION_BACKOFFS = [60, 120, 300, 900]
+# Backoff (seconds) for re-testing an inconclusive new code, then the 2h loop.
+# Never sub-60s: a common cause is an API rate-limit, and retrying sooner just
+# sustains the throttle.
+_REVALIDATION_BACKOFFS = [60, 120, 300, 600, 900]
 
 
 async def handle_gift_validate_process(cog, process):
@@ -105,13 +105,16 @@ async def handle_gift_validate_process(cog, process):
             except Exception:
                 message = None
 
-    # Check if code already exists
-    cog.cursor.execute("SELECT 1 FROM gift_codes WHERE giftcode = ?", (giftcode,))
-    if cog.cursor.fetchone():
+    # A code we hold as 'invalid' that shows up again is a reactivation candidate:
+    # re-validate it instead of bailing. Other stored statuses stay "already exists".
+    cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
+    row = cog.cursor.fetchone()
+    if row and row[0] != 'invalid':
         cog.logger.info(f"Code '{giftcode}' already exists in database.")
         if message and channel:
             await _send_existing_code_response(cog, message, giftcode, channel)
         return
+    was_invalid = row is not None and row[0] == 'invalid'
 
     # Show processing message if from channel
     processing_message = None
@@ -126,15 +129,25 @@ async def handle_gift_validate_process(cog, process):
         except Exception:
             processing_message = None
 
-    # Perform validation
-    is_valid, validation_msg = await validate_gift_code_immediately(cog, giftcode, source)
+    # Perform validation (force a live re-probe for a reactivation candidate).
+    is_valid, validation_msg = await validate_gift_code_immediately(cog, giftcode, source, force=was_invalid)
 
     # Handle validation result
     if message and channel:
         await _send_validation_response(cog, message, giftcode, is_valid, validation_msg, processing_message)
 
-    # Valid -> redeem; inconclusive -> re-test on a short backoff (else the 2h loop).
+    # Valid -> share to API + redeem; inconclusive -> re-test on a short backoff.
     if is_valid:
+        if was_invalid:
+            # Genuine reactivation: clear old redemptions so members can claim again.
+            try:
+                cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (giftcode,))
+                cog.conn.commit()
+                cog.logger.info(f"🔄 REACTIVATION: '{giftcode}' re-validated valid via {source}; cleared old redemption records")
+            except Exception as e:
+                cog.logger.error(f"Error clearing reactivation history for '{giftcode}': {e}")
+        if hasattr(cog, 'api') and cog.api:
+            asyncio.create_task(cog.api.add_giftcode(giftcode))
         await _process_auto_use(cog, giftcode)
     elif is_valid is None:
         schedule_revalidation(cog, giftcode, source)
@@ -251,7 +264,7 @@ async def _send_validation_response(cog, message, giftcode, is_valid, validation
         )
         reaction = f"{theme.deniedIcon}"
     else:
-        reply_embed = discord.Embed(title=f"{theme.warnIcon} Gift Code Added (Pending)", color=discord.Color.yellow())
+        reply_embed = discord.Embed(title=f"{theme.warnIcon} Gift Code Added (Validating)", color=discord.Color.yellow())
         reply_embed.description = (
             f"**Gift Code Details**\n{theme.upperDivider}\n"
             f"{theme.userIcon} **Sender:** {message.author.mention}\n"
@@ -538,16 +551,34 @@ async def _update_batch_progress(cog, batch_id):
         cog.logger.warning(f"Failed to update batch progress message: {e}")
 
 
-async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
-    """Immediately validate a gift code when it's added from any source.
+# Conclusive validation outcomes: the API gave a definitive verdict on the code.
+VALID_REDEEM_STATUSES = ("SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE", "TOO_SMALL_SPEND_MORE", "TOO_POOR_SPEND_MORE")
+INVALID_REDEEM_STATUSES = ("TIME_ERROR", "CDK_NOT_FOUND", "USAGE_LIMIT")
+CONCLUSIVE_REDEEM_STATUSES = VALID_REDEEM_STATUSES + INVALID_REDEEM_STATUSES
 
-    Args:
-        giftcode: The gift code to validate
-        source: Where the code came from ('api', 'button', 'channel')
 
-    Returns:
-        tuple: (is_valid, status_message)
-    """
+async def get_alt_validation_fids(cog, exclude, limit=3):
+    """Random alliance-member FIDs to validate with when the primary FID is inconclusive or dead."""
+    def _query():
+        with sqlite3.connect('db/users.sqlite', timeout=30.0) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT fid FROM users WHERE alliance IS NOT NULL AND alliance != '' ORDER BY RANDOM() LIMIT ?",
+                (limit + len(exclude),),
+            )
+            return [row[0] for row in cursor.fetchall()]
+    try:
+        fids = await asyncio.to_thread(_query)
+    except Exception as e:
+        cog.logger.warning(f"GiftOps: could not fetch alternate validation FIDs: {e}")
+        return []
+    excl = {str(e) for e in exclude}
+    return [f for f in fids if str(f) not in excl][:limit]
+
+
+async def validate_gift_code_immediately(cog, giftcode, source="unknown", force=False):
+    """Validate a code against the live game API. Returns (is_valid, message).
+    force=True re-probes even a code already stored as validated/invalid (reactivation)."""
     try:
         # Clean the gift code
         giftcode = cog.clean_gift_code(giftcode)
@@ -557,25 +588,34 @@ async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
 
         cog.logger.info(f"Validating gift code '{giftcode}' from {source} using {fid_source} ID: {validation_fid}")
 
-        # Check if already validated
-        cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
-        existing = cog.cursor.fetchone()
-
-        if existing:
-            status = existing[0]
-            if status == 'invalid':
-                cog.logger.info(f"Gift code '{giftcode}' already marked as invalid")
-                return False, "Code already marked as invalid"
-            elif status == 'validated':
-                cog.logger.info(f"Gift code '{giftcode}' already validated")
-                return True, "Code already validated"
+        # Short-circuit on a known verdict unless forced to re-probe (e.g. reactivation).
+        if not force:
+            cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (giftcode,))
+            existing = cog.cursor.fetchone()
+            if existing:
+                status = existing[0]
+                if status == 'invalid':
+                    cog.logger.info(f"Gift code '{giftcode}' already marked as invalid")
+                    return False, "Code already marked as invalid"
+                elif status == 'validated':
+                    cog.logger.info(f"Gift code '{giftcode}' already validated")
+                    return True, "Code already validated"
 
         # Perform validation using the selected ID — skip the cache so we
         # actually probe the live API (the whole point of validating).
         status = await claim_giftcode_rewards_wos(cog, validation_fid, giftcode, skip_cache=True)
 
+        # If the primary FID gave no definitive verdict, rotate to fresh member
+        # FIDs so a valid code gets confirmed now instead of parking as "Validating".
+        if status not in CONCLUSIVE_REDEEM_STATUSES:
+            for alt_fid in await get_alt_validation_fids(cog, exclude={validation_fid}):
+                cog.logger.info(f"Validation of '{giftcode}' inconclusive on FID {validation_fid} ({status}); retrying with member FID {alt_fid}")
+                status = await claim_giftcode_rewards_wos(cog, alt_fid, giftcode, skip_cache=True)
+                if status in CONCLUSIVE_REDEEM_STATUSES:
+                    break
+
         # Handle validation results
-        if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE", "TOO_SMALL_SPEND_MORE", "TOO_POOR_SPEND_MORE"]:
+        if status in VALID_REDEEM_STATUSES:
             # Valid code - mark as validated
             cog.cursor.execute("""
                 INSERT OR REPLACE INTO gift_codes (giftcode, date, validation_status)
@@ -593,7 +633,7 @@ async def validate_gift_code_immediately(cog, giftcode, source="unknown"):
 
             return True, validation_msg
 
-        elif status in ["TIME_ERROR", "CDK_NOT_FOUND", "USAGE_LIMIT"]:
+        elif status in INVALID_REDEEM_STATUSES:
             # Invalid code - mark as invalid
             mark_code_invalid(cog, giftcode)
 
@@ -634,19 +674,147 @@ def encode_data(cog, data):
     return {"sign": sign, **data}
 
 
+# Bidi isolates so RTL names (Arabic/Hebrew) don't flip surrounding LTR text.
+_FSI = "⁨"
+_PDI = "⁩"
+
+
+def _iso(text) -> str:
+    return f"{_FSI}{text}{_PDI}"
+
+
+def get_summary_settings(cog, alliance_id):
+    """Per-alliance redemption-summary config; None-safe, defaults to disabled."""
+    try:
+        cog.settings_cursor.execute(
+            "SELECT enabled, show_success, show_already, show_failed "
+            "FROM redemption_summary_settings WHERE alliance_id = ?",
+            (alliance_id,),
+        )
+        row = cog.settings_cursor.fetchone()
+    except Exception:
+        return {"enabled": 0, "success": 0, "already": 0, "failed": 0}
+    if not row:
+        return {"enabled": 0, "success": 0, "already": 0, "failed": 0}
+    return {"enabled": row[0], "success": row[1], "already": row[2], "failed": row[3]}
+
+
+def set_summary_settings(cog, alliance_id, *, enabled=None, success=None, already=None, failed=None):
+    cur = get_summary_settings(cog, alliance_id)
+    enabled = cur["enabled"] if enabled is None else int(enabled)
+    success = cur["success"] if success is None else int(success)
+    already = cur["already"] if already is None else int(already)
+    failed = cur["failed"] if failed is None else int(failed)
+    cog.settings_cursor.execute(
+        "INSERT INTO redemption_summary_settings "
+        "(alliance_id, enabled, show_success, show_already, show_failed) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(alliance_id) DO UPDATE SET enabled = excluded.enabled, "
+        "show_success = excluded.show_success, show_already = excluded.show_already, "
+        "show_failed = excluded.show_failed",
+        (alliance_id, enabled, success, already, failed),
+    )
+    cog.settings_conn.commit()
+
+
+def _summary_names_block(names, limit=1024) -> str:
+    """One name per line, truncated to fit `limit` chars, with an overflow pointer to Redemption History."""
+    out, used = [], 0
+    for n in names:
+        need = len(n) + 1  # + newline
+        if used + need > limit - 45:  # reserve room for the overflow note
+            break
+        out.append(n)
+        used += need
+    text = "\n".join(out)
+    more = len(names) - len(out)
+    if more > 0:
+        text += f"\n…and {more} more - see Redemption History"
+    return text
+
+
+async def post_redemption_summary(cog, channel, alliance_id, alliance_name, giftcode,
+                                  successful_users, already_used_users, failed_users_dict):
+    """Post the opt-in per-alliance summary as up to three static, silent messages
+    (Redeemed / Already Redeemed / Failed). Separate messages so each gets its own
+    embed budget; silent so they don't ping alongside the redemption progress post.
+    No buttons - it's a persistent public log; the filterable per-player view is the
+    on-demand, in-menu Redemption History screen."""
+    if channel is None:
+        return
+    s = get_summary_settings(cog, alliance_id)
+    if not s or not s["enabled"]:
+        return
+
+    head = f"Alliance: **{alliance_name}**"
+
+    async def _post(embed):
+        try:
+            try:
+                await channel.send(embed=embed, silent=True)
+            except TypeError:  # older discord.py without silent=
+                await channel.send(embed=embed)
+        except Exception as e:
+            cog.logger.exception(f"GiftOps: Error posting redemption summary for {alliance_id}: {e}")
+
+    if s["success"] and successful_users:
+        block = _summary_names_block([_iso(n) for n in successful_users], 3800)
+        await _post(discord.Embed(
+            title=f"{theme.verifiedIcon} Redeemed - {giftcode} ({len(successful_users)})",
+            description=f"{head}\n\n{block}", color=theme.emColor3))
+
+    if s["already"] and already_used_users:
+        block = _summary_names_block([_iso(n) for n in already_used_users], 3800)
+        await _post(discord.Embed(
+            title=f"{theme.giftIcon} Already Redeemed - {giftcode} ({len(already_used_users)})",
+            description=f"{head}\n\n{block}", color=theme.emColor1))
+
+    if s["failed"] and failed_users_dict:
+        by_reason = {}
+        for fid, (nick, reason, _cycles) in failed_users_dict.items():
+            by_reason.setdefault(reason, []).append(f"{_iso(nick)} ({fid})")
+        embed = discord.Embed(
+            title=f"{theme.deniedIcon} Failed - {giftcode} ({len(failed_users_dict)})",
+            description=head, color=theme.emColor2)
+        total = len(head)
+        for reason, names in sorted(by_reason.items(), key=lambda kv: len(kv[1]), reverse=True):
+            value = _summary_names_block(names, 1024)
+            if len(embed.fields) >= 24 or total + len(reason) + len(value) > 5800:
+                embed.add_field(name="…", value="More players listed in Redemption History.", inline=False)
+                break
+            embed.add_field(name=f"{theme.deniedIcon} {reason}", value=value, inline=False)
+            total += len(reason) + len(value)
+        await _post(embed)
+        if self.message:
+            try:
+                await self.message.edit(view=self)
+            except Exception:
+                pass
+
+
 def batch_insert_user_giftcodes(cog, user_giftcode_data):
-    """Batch insert/update user giftcode records for better performance."""
+    """Batch upsert per-account redemption results (success and failure).
+
+    Never downgrades an existing SUCCESS/RECEIVED/SAME TYPE EXCHANGE to a later
+    failure (an account that succeeded on retry stays successful), and refreshes
+    last_attempt_at so the redeem-results viewer can show when it last ran.
+    """
     if not user_giftcode_data:
         return
 
-    try: # Executemany for batch operations - much faster than individual inserts
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    rows = [(fid, giftcode, status, ts) for (fid, giftcode, status) in user_giftcode_data]
+    try:
         cog.cursor.executemany("""
-            INSERT OR REPLACE INTO user_giftcodes (fid, giftcode, status)
-            VALUES (?, ?, ?)
-        """, user_giftcode_data)
+            INSERT INTO user_giftcodes (fid, giftcode, status, last_attempt_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(fid, giftcode) DO UPDATE SET
+                status = excluded.status,
+                last_attempt_at = excluded.last_attempt_at
+            WHERE user_giftcodes.status NOT IN ('SUCCESS', 'RECEIVED', 'SAME TYPE EXCHANGE')
+        """, rows)
 
         cog.conn.commit()
-        cog.logger.info(f"GiftOps: Batch inserted/updated {len(user_giftcode_data)} user giftcode records")
+        cog.logger.info(f"GiftOps: Recorded {len(rows)} user giftcode result(s)")
 
     except Exception as e:
         cog.logger.exception(f"GiftOps: Error in batch_insert_user_giftcodes: {e}")
@@ -721,24 +889,20 @@ def batch_process_alliance_results(cog, results_batch):
         return
 
     try:
-        # Separate successful results
-        successful_records = []
-        codes_to_validate = set()
+        codes_to_validate = {
+            giftcode for fid, giftcode, status in results_batch
+            if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE"]
+        }
 
-        for fid, giftcode, status in results_batch:
-            if status in ["SUCCESS", "RECEIVED", "SAME TYPE EXCHANGE"]:
-                successful_records.append((fid, giftcode, status))
-                codes_to_validate.add(giftcode)
+        # Persist every per-account outcome (success and failure) so Redeem
+        # History has the full picture; the upsert never downgrades a success.
+        batch_insert_user_giftcodes(cog, results_batch)
 
-        # Batch insert successful records
-        if successful_records:
-            batch_insert_user_giftcodes(cog, successful_records)
-
-        # Batch validate codes
+        # Batch validate codes (only codes that had at least one success)
         if codes_to_validate:
             batch_update_gift_codes_validation(cog, list(codes_to_validate))
 
-        cog.logger.info(f"GiftOps: Batch processed {len(successful_records)} successful, {len(codes_to_validate)} validated")
+        cog.logger.info(f"GiftOps: Batch processed {len(results_batch)} result(s), {len(codes_to_validate)} validated")
 
     except Exception as e:
         cog.logger.exception(f"GiftOps: Error in batch_process_alliance_results: {e}")
@@ -1073,6 +1237,12 @@ async def scan_historical_messages(cog, channel: discord.TextChannel, alliance_i
                 # Store validation result
                 scan_results['validation_results'][giftcode] = is_valid
 
+                # Valid -> share to the API and auto-redeem for enabled alliances.
+                if is_valid:
+                    if hasattr(cog, 'api') and cog.api:
+                        asyncio.create_task(cog.api.add_giftcode(giftcode))
+                    await _process_auto_use(cog, giftcode)
+
                 # Add appropriate reaction to message
                 if giftcode in message_code_map:
                     message = message_code_map[giftcode]
@@ -1190,7 +1360,7 @@ async def _send_scan_results_message(cog, channel: discord.TextChannel, results:
         if results['existing_invalid']:
             existing_summary += f"{theme.deniedIcon} Previously Invalid: {len(results['existing_invalid'])}\n"
         if results['existing_pending']:
-            existing_summary += f"{theme.warnIcon} Pending Validation: {len(results['existing_pending'])}\n"
+            existing_summary += f"{theme.warnIcon} Validating: {len(results['existing_pending'])}\n"
 
         if existing_summary:
             embed.add_field(
@@ -1817,6 +1987,12 @@ async def use_giftcode_for_alliance(cog, alliance_id, giftcode):
         if batch_results:
             batch_process_alliance_results(cog, batch_results)
             batch_results = []
+
+        # Opt-in per-alliance summary embed after the run.
+        await post_redemption_summary(
+            cog, channel, alliance_id, alliance_name, giftcode,
+            successful_users, already_used_users, failed_users_dict,
+        )
 
         return True
 

--- a/cogs/gift_redemption_results.py
+++ b/cogs/gift_redemption_results.py
@@ -1,0 +1,339 @@
+"""Gift code Redemption History viewer: per-account outcomes (redeemed / already
+redeemed / failed) for a chosen code, paginated and filterable by alliance.
+
+Single view — the code dropdown lives inside it; the filter/pagination controls
+stay disabled until a code is picked."""
+
+import asyncio
+import sqlite3
+import logging
+
+import discord
+
+from .pimp_my_bot import theme, safe_edit_message, check_interaction_user, disable_expired_view
+from .permission_handler import PermissionManager
+
+logger = logging.getLogger('gift')
+
+PAGE_SIZE = 20
+
+# Reuse the proven RTL helpers shared with bear_track / attendance: an LRM prefix
+# keeps the whole line left-to-right (so icons/numbers/parens stay in order) while
+# each RTL name is wrapped in an FSI…PDI isolate. The local LRI…PDI wrapping did
+# not render LTR in Discord.
+from .bear_track import _isolate_rtl, _ltr_line
+
+
+SUCCESS_STATUSES = {"SUCCESS", "SAME TYPE EXCHANGE"}
+ALREADY_STATUSES = {"RECEIVED"}
+# The code itself is bad/expired — not a per-account outcome. Shown as a banner.
+CODE_LEVEL_STATUSES = {"CDK_NOT_FOUND", "USAGE_LIMIT", "TIME_ERROR"}
+
+STATUS_LABELS = {
+    "SUCCESS": "Redeemed",
+    "SAME TYPE EXCHANGE": "Redeemed",
+    "RECEIVED": "Already redeemed",
+    "CONNECTION_ERROR": "Connection error",
+    "CAPTCHA_INVALID": "Captcha failed",
+    "ERROR": "Error",
+}
+
+BUCKET_ORDER = ("success", "already", "failed")
+BUCKET_META = {
+    "success": ("Redeemed", "verifiedIcon"),
+    "already": ("Already Redeemed", "giftIcon"),
+    "failed": ("Failed", "deniedIcon"),
+}
+
+
+def _bucket(status: str) -> str:
+    if status in SUCCESS_STATUSES:
+        return "success"
+    if status in ALREADY_STATUSES:
+        return "already"
+    if status in CODE_LEVEL_STATUSES:
+        return "code"
+    return "failed"
+
+
+def _load_results(giftcode: str, cursor_rows):
+    """Merge redemption rows (giftcode.sqlite) with nicknames/alliance
+    (users.sqlite, a separate DB — so no cross-DB join)."""
+    fids = [r[0] for r in cursor_rows]
+    users = {}
+    if fids:
+        with sqlite3.connect('db/users.sqlite', timeout=30.0) as uconn:
+            ucur = uconn.cursor()
+            for i in range(0, len(fids), 500):
+                chunk = fids[i:i + 500]
+                placeholders = ",".join("?" * len(chunk))
+                ucur.execute(
+                    f"SELECT fid, nickname, alliance FROM users WHERE fid IN ({placeholders})",
+                    chunk,
+                )
+                for fid, nickname, alliance in ucur.fetchall():
+                    users[fid] = (nickname, alliance)
+
+    rows = []
+    for fid, status, ts in cursor_rows:
+        nickname, alliance = users.get(fid, (None, None))
+        rows.append({
+            "fid": fid,
+            "nickname": nickname or str(fid),
+            "alliance": str(alliance) if alliance is not None else None,
+            "status": status,
+            "bucket": _bucket(status),
+            "ts": ts,
+        })
+    return rows
+
+
+async def show_redeem_results(cog, interaction: discord.Interaction):
+    """Entry point from the main Gift Code menu."""
+    is_admin, _ = PermissionManager.is_admin(interaction.user.id)
+    if not is_admin:
+        msg = f"{theme.deniedIcon} Only bot admins can view redeem history."
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+
+    cog.cursor.execute("SELECT giftcode, date FROM gift_codes ORDER BY date DESC LIMIT 25")
+    codes = cog.cursor.fetchall()
+    alliances, is_global = PermissionManager.get_admin_alliances(
+        interaction.user.id, interaction.guild_id or 0
+    )
+    allowed_ids = None if is_global else {str(aid) for aid, _ in alliances}
+
+    view = RedeemHistoryView(cog, interaction.user.id, codes, alliances, allowed_ids)
+    await safe_edit_message(interaction, embed=view.build_embed(), view=view, content=None)
+    view.message = await interaction.original_response()
+
+
+class RedeemHistoryView(discord.ui.View):
+    """One-screen Redemption History: code dropdown + alliance filter + status
+    toggles + pagination. Everything but the code dropdown and Back is disabled
+    until a code is selected."""
+
+    def __init__(self, cog, user_id, codes, alliances, allowed_ids):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.user_id = user_id
+        self.codes = codes                  # [(giftcode, date), ...]
+        self.alliances = alliances          # [(alliance_id, name), ...]
+        self.allowed_ids = allowed_ids      # None => global (all)
+        self.message = None
+
+        self.selected_code = None
+        self.all_rows = []                  # permission-scoped rows for selected code
+        self.alliance_filter = None         # None => all accessible
+        self.active_buckets = set(BUCKET_ORDER)
+        self.page = 0
+        self._build_components()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_interaction_user(interaction, self.user_id)
+
+    # --- data helpers ---------------------------------------------------
+    def _alliance_rows(self):
+        if self.alliance_filter is None:
+            return self.all_rows
+        return [r for r in self.all_rows if r["alliance"] == self.alliance_filter]
+
+    def _counts(self, rows):
+        counts = {"success": 0, "already": 0, "failed": 0, "code": 0}
+        for r in rows:
+            counts[r["bucket"]] = counts.get(r["bucket"], 0) + 1
+        return counts
+
+    def _visible_rows(self, rows):
+        return [r for r in rows if r["bucket"] in self.active_buckets]
+
+    def _alliance_name(self, alliance_id):
+        for aid, name in self.alliances:
+            if str(aid) == str(alliance_id):
+                return name
+        return f"Alliance {alliance_id}"
+
+    # --- rendering ------------------------------------------------------
+    def build_embed(self) -> discord.Embed:
+        if not self.codes:
+            return discord.Embed(
+                title=f"{theme.archiveIcon} Redemption History",
+                description="No gift codes have been added yet.",
+                color=theme.emColor1,
+            )
+        if self.selected_code is None:
+            return discord.Embed(
+                title=f"{theme.archiveIcon} Redemption History",
+                description=(
+                    "Pick a gift code above to see which accounts redeemed it, "
+                    "already had it, or failed."
+                ),
+                color=theme.emColor1,
+            )
+
+        arows = self._alliance_rows()
+        counts = self._counts(arows)
+        visible = self._visible_rows(arows)
+
+        total_pages = max(1, (len(visible) + PAGE_SIZE - 1) // PAGE_SIZE)
+        self.page = max(0, min(self.page, total_pages - 1))
+        page_rows = visible[self.page * PAGE_SIZE:(self.page + 1) * PAGE_SIZE]
+
+        header = (
+            f"{theme.verifiedIcon} Redeemed: `{counts['success']}`  "
+            f"{theme.giftIcon} Already: `{counts['already']}`  "
+            f"{theme.deniedIcon} Failed: `{counts['failed']}`"
+        )
+
+        lines = []
+        if counts["code"]:
+            lines.append(
+                f"{theme.warnIcon} This code looks invalid or expired for "
+                f"`{counts['code']}` account(s) (bad/expired code)."
+            )
+            lines.append("")
+
+        if not page_rows:
+            lines.append("_No accounts match the current filters._")
+        else:
+            icons = {b: getattr(theme, BUCKET_META[b][1]) for b in BUCKET_ORDER}
+            for r in page_rows:
+                label = STATUS_LABELS.get(r["status"], r["status"])
+                name = _isolate_rtl(r["nickname"])
+                lines.append(_ltr_line(f"{icons[r['bucket']]} **{name}** (`{r['fid']}`) - {label}"))
+
+        scope = "All alliances" if self.alliance_filter is None else self._alliance_name(self.alliance_filter)
+        return discord.Embed(
+            title=f"{theme.archiveIcon} Redemption History - {self.selected_code}",
+            description=(
+                f"{header}\n"
+                f"{theme.upperDivider}\n"
+                + "\n".join(lines)
+                + f"\n{theme.lowerDivider}\n"
+                f"Scope: **{scope}**  ·  Page **{self.page + 1}/{total_pages}**"
+            ),
+            color=theme.emColor1,
+        )
+
+    def _build_components(self):
+        self.clear_items()
+        has_code = self.selected_code is not None
+
+        # Row 0: gift code picker (always active).
+        if self.codes:
+            options = [
+                discord.SelectOption(
+                    label=code[:100],
+                    description=(f"Added {date}" if date else None),
+                    value=code,
+                    default=code == self.selected_code,
+                )
+                for code, date in self.codes
+            ]
+            code_select = discord.ui.Select(
+                placeholder="Pick a gift code", options=options, row=0,
+            )
+            code_select.callback = self._on_code
+            self.add_item(code_select)
+
+        # Row 1: alliance filter (only when more than one is accessible).
+        if self.alliances and len(self.alliances) > 1:
+            opts = [discord.SelectOption(
+                label="All alliances", value="__all__",
+                default=self.alliance_filter is None,
+            )]
+            for aid, name in self.alliances[:24]:
+                opts.append(discord.SelectOption(
+                    label=name[:100], value=str(aid),
+                    default=str(aid) == str(self.alliance_filter),
+                ))
+            asel = discord.ui.Select(
+                placeholder="Filter by alliance", options=opts, row=1, disabled=not has_code,
+            )
+            asel.callback = self._on_alliance
+            self.add_item(asel)
+
+        # Row 2: status filter toggles with live counts (disabled until a code).
+        counts = self._counts(self._alliance_rows())
+        for bucket in BUCKET_ORDER:
+            title, icon_name = BUCKET_META[bucket]
+            on = bucket in self.active_buckets
+            btn = discord.ui.Button(
+                label=f"{title} ({counts[bucket]})",
+                emoji=getattr(theme, icon_name),
+                style=discord.ButtonStyle.success if on else discord.ButtonStyle.secondary,
+                row=2,
+                disabled=not has_code,
+            )
+            btn.callback = self._make_toggle(bucket)
+            self.add_item(btn)
+
+        # Row 3: pagination (disabled until a code).
+        prev_btn = discord.ui.Button(label="Prev", emoji=f"{theme.prevIcon}", style=discord.ButtonStyle.primary, row=3, disabled=not has_code)
+        prev_btn.callback = self._prev
+        self.add_item(prev_btn)
+        next_btn = discord.ui.Button(label="Next", emoji=f"{theme.nextIcon}", style=discord.ButtonStyle.primary, row=3, disabled=not has_code)
+        next_btn.callback = self._next
+        self.add_item(next_btn)
+
+        # Row 4: Back only (returns to the gift menu).
+        back_btn = discord.ui.Button(label="Back", emoji=f"{theme.backIcon}", style=discord.ButtonStyle.secondary, row=4)
+        back_btn.callback = self._back
+        self.add_item(back_btn)
+
+    async def _refresh(self, interaction: discord.Interaction):
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
+
+    # --- callbacks ------------------------------------------------------
+    async def _on_code(self, interaction: discord.Interaction):
+        self.selected_code = interaction.data["values"][0]
+        await interaction.response.defer()
+        self.cog.cursor.execute(
+            "SELECT fid, status, last_attempt_at FROM user_giftcodes WHERE giftcode = ?",
+            (self.selected_code,),
+        )
+        cursor_rows = self.cog.cursor.fetchall()
+        rows = await asyncio.to_thread(_load_results, self.selected_code, cursor_rows)
+        if self.allowed_ids is None:
+            self.all_rows = rows
+        else:
+            self.all_rows = [r for r in rows if r["alliance"] in self.allowed_ids]
+        self.alliance_filter = None
+        self.active_buckets = set(BUCKET_ORDER)
+        self.page = 0
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
+
+    async def _on_alliance(self, interaction: discord.Interaction):
+        value = interaction.data["values"][0]
+        self.alliance_filter = None if value == "__all__" else value
+        self.page = 0
+        await self._refresh(interaction)
+
+    def _make_toggle(self, bucket):
+        async def _toggle(interaction: discord.Interaction):
+            if bucket in self.active_buckets:
+                self.active_buckets.discard(bucket)
+            else:
+                self.active_buckets.add(bucket)
+            self.page = 0
+            await self._refresh(interaction)
+        return _toggle
+
+    async def _prev(self, interaction: discord.Interaction):
+        self.page -= 1
+        await self._refresh(interaction)
+
+    async def _next(self, interaction: discord.Interaction):
+        self.page += 1
+        await self._refresh(interaction)
+
+    async def _back(self, interaction: discord.Interaction):
+        await self.cog.show_gift_menu(interaction)
+
+    async def on_timeout(self):
+        await disable_expired_view(self)

--- a/cogs/gift_settings.py
+++ b/cogs/gift_settings.py
@@ -6,8 +6,9 @@ import logging
 import requests
 import json
 
-from .pimp_my_bot import theme, safe_edit_message
+from .pimp_my_bot import theme, safe_edit_message, check_interaction_user, notify_view_expired
 from .alliance_member_operations import AllianceSelectView
+from .permission_handler import PermissionManager
 
 logger = logging.getLogger('gift')
 
@@ -85,6 +86,46 @@ def get_test_fid(cog):
     except Exception as e:
         cog.logger.exception(f"Error getting test ID: {e}")
         return "43180889"
+
+
+async def update_test_fid(cog, new_fid):
+    """
+    Update the test ID in the database.
+
+    Args:
+        new_fid (str): The new test ID
+
+    Returns:
+        bool: True if update was successful, False otherwise
+    """
+    try:
+        cog.logger.info(f"Updating test ID to: {new_fid}")
+
+        cog.settings_cursor.execute("""
+            INSERT INTO test_fid_settings (test_fid) VALUES (?)
+        """, (new_fid,))
+        cog.settings_conn.commit()
+
+        cog.logger.info(f"Test ID updated successfully to {new_fid}")
+        return True
+
+    except sqlite3.Error as db_err:
+        cog.logger.exception(f"Database error updating test ID: {db_err}")
+        return False
+    except Exception as e:
+        cog.logger.exception(f"Unexpected error updating test ID: {e}")
+        return False
+
+
+def clear_test_fid(cog):
+    """Remove any configured test FID so validation rotates through random alliance members."""
+    try:
+        cog.settings_cursor.execute("DELETE FROM test_fid_settings")
+        cog.settings_conn.commit()
+        return True
+    except Exception as e:
+        cog.logger.exception(f"Error clearing test ID: {e}")
+        return False
 
 
 async def get_validation_fid(cog):
@@ -675,3 +716,180 @@ class ClearCacheConfirmView(discord.ui.View):
     async def on_timeout(self):
         for item in self.children:
             item.disabled = True
+
+
+class TestIDModal(discord.ui.Modal, title="Set Test ID"):
+    def __init__(self, cog):
+        super().__init__()
+        self.cog = cog
+
+        try:
+            self.cog.settings_cursor.execute("SELECT test_fid FROM test_fid_settings ORDER BY id DESC LIMIT 1")
+            result = self.cog.settings_cursor.fetchone()
+            current_fid = result[0] if result and result[0] != "43180889" else ""
+        except Exception:
+            current_fid = ""
+
+        self.test_fid = discord.ui.TextInput(
+            label="Player ID (blank = rotate members)",
+            placeholder="Leave blank to validate with random alliance members",
+            default=current_fid,
+            required=False,
+            max_length=20
+        )
+        self.add_item(self.test_fid)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            raw = self.test_fid.value.strip()
+            if not raw:
+                self.cog.clear_test_fid()
+                self.cog.logger.info(f"Test FID cleared by {interaction.user.id}; validation will rotate alliance members.")
+            elif not raw.isdigit():
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Invalid ID. Enter a numeric player ID, or leave it blank to rotate alliance members.",
+                    ephemeral=True)
+                return
+            else:
+                await self.cog.update_test_fid(raw)
+                self.cog.logger.info(f"Test FID set to {raw} by {interaction.user.id}.")
+
+            # Refresh the settings menu in place so it shows the new mode.
+            await self.cog.show_settings_menu(interaction)
+        except Exception as e:
+            self.cog.logger.exception(f"Error setting test ID: {e}")
+            if not interaction.response.is_done():
+                await interaction.response.send_message(f"{theme.deniedIcon} An error occurred: {str(e)}", ephemeral=True)
+
+
+async def show_redemption_summary(cog, interaction: discord.Interaction):
+    """Per-alliance config for the post-redemption summary embed."""
+    alliances, _ = PermissionManager.get_admin_alliances(
+        interaction.user.id, interaction.guild_id or 0
+    )
+    if not alliances:
+        msg = f"{theme.deniedIcon} You have no alliances to configure."
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+    view = RedemptionSummaryView(cog, interaction.user.id, alliances)
+    await safe_edit_message(interaction, embed=view.build_embed(), view=view, content=None)
+    view.message = await interaction.original_response()
+
+
+class RedemptionSummaryView(discord.ui.View):
+    """Pick an alliance, then toggle whether/what its redemption summary posts."""
+
+    def __init__(self, cog, user_id: int, alliances):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.user_id = user_id
+        self.alliances = alliances            # [(alliance_id, name), ...]
+        self.selected_id = None
+        self.message = None
+        self._build_components()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await check_interaction_user(interaction, self.user_id)
+
+    def _settings(self):
+        from .gift_redemption import get_summary_settings
+        return get_summary_settings(self.cog, self.selected_id) if self.selected_id else None
+
+    def _build_components(self):
+        self.clear_items()
+        options = [
+            discord.SelectOption(
+                label=name[:100], value=str(aid),
+                default=str(aid) == str(self.selected_id),
+            )
+            for aid, name in self.alliances[:25]
+        ]
+        select = discord.ui.Select(placeholder="Select an alliance", options=options, row=0)
+        select.callback = self._on_alliance
+        self.add_item(select)
+
+        s = self._settings()
+        if s is not None:
+            self._add_toggle("Summary", theme.redeemIcon, bool(s["enabled"]), self._toggle_enabled, row=1)
+            if s["enabled"]:
+                self._add_toggle("Successful", theme.verifiedIcon, bool(s["success"]), self._toggle_success, row=2)
+                self._add_toggle("Already Redeemed", theme.giftIcon, bool(s["already"]), self._toggle_already, row=2)
+                self._add_toggle("Failed", theme.deniedIcon, bool(s["failed"]), self._toggle_failed, row=2)
+
+        back = discord.ui.Button(label="Back", emoji=f"{theme.backIcon}", style=discord.ButtonStyle.secondary, row=3)
+        back.callback = self._back
+        self.add_item(back)
+
+    def _add_toggle(self, label, emoji, enabled, callback, row):
+        btn = discord.ui.Button(
+            label=f"{label}: {'On' if enabled else 'Off'}",
+            emoji=f"{emoji}",
+            style=discord.ButtonStyle.success if enabled else discord.ButtonStyle.secondary,
+            row=row,
+        )
+        btn.callback = callback
+        self.add_item(btn)
+
+    def build_embed(self) -> discord.Embed:
+        desc = (
+            "Choose an alliance, then turn its post-redemption summary on or off "
+            "and pick which results it lists.\n\n"
+            "When on, the bot posts one embed in the gift channel after each code "
+            "finishes for that alliance, listing the buckets you enable.\n"
+        )
+        s = self._settings()
+        if s is not None:
+            name = next((n for a, n in self.alliances if str(a) == str(self.selected_id)), self.selected_id)
+            if not s["enabled"]:
+                state = f"{theme.deniedIcon} Off"
+            else:
+                picked = [lbl for lbl, on in (
+                    ("Successful", s["success"]), ("Already Redeemed", s["already"]), ("Failed", s["failed"])
+                ) if on]
+                state = f"{theme.verifiedIcon} On — " + (", ".join(picked) if picked else "no buckets selected yet")
+            desc += f"\n{theme.upperDivider}\n**{name}:** {state}\n{theme.lowerDivider}"
+        return discord.Embed(
+            title=f"{theme.redeemIcon} Redemption Summary",
+            description=desc,
+            color=theme.emColor1,
+        )
+
+    async def _refresh(self, interaction: discord.Interaction):
+        self._build_components()
+        await safe_edit_message(interaction, embed=self.build_embed(), view=self, content=None)
+
+    async def _on_alliance(self, interaction: discord.Interaction):
+        self.selected_id = int(interaction.data["values"][0])
+        await self._refresh(interaction)
+
+    async def _set(self, interaction, **kwargs):
+        from .gift_redemption import set_summary_settings
+        set_summary_settings(self.cog, self.selected_id, **kwargs)
+        await self._refresh(interaction)
+
+    async def _toggle_enabled(self, interaction):
+        s = self._settings()
+        turning_on = not s["enabled"]
+        kwargs = {"enabled": turning_on}
+        # Sensible default on first enable: show Failed (the actionable bucket).
+        if turning_on and not (s["success"] or s["already"] or s["failed"]):
+            kwargs["failed"] = True
+        await self._set(interaction, **kwargs)
+
+    async def _toggle_success(self, interaction):
+        await self._set(interaction, success=not self._settings()["success"])
+
+    async def _toggle_already(self, interaction):
+        await self._set(interaction, already=not self._settings()["already"])
+
+    async def _toggle_failed(self, interaction):
+        await self._set(interaction, failed=not self._settings()["failed"])
+
+    async def _back(self, interaction: discord.Interaction):
+        await self.cog.show_settings_menu(interaction)
+
+    async def on_timeout(self):
+        await notify_view_expired(self, "redemption summary settings")

--- a/cogs/gift_views.py
+++ b/cogs/gift_views.py
@@ -185,7 +185,7 @@ async def delete_gift_code(cog, interaction: discord.Interaction):
             elif validation_status == 'invalid':
                 status_display = f"{theme.deniedIcon} Invalid"
             elif validation_status == 'pending':
-                status_display = f"{theme.warnIcon} Pending"
+                status_display = f"{theme.warnIcon} Validating"
             else:
                 status_display = f"{theme.infoIcon} Unknown"
 
@@ -372,7 +372,13 @@ async def show_settings_menu(cog, interaction: discord.Interaction):
             f"{theme.chartIcon} **Redemption Priority**\n"
             f"└ Change the order in which alliances auto-redeem new gift codes\n\n"
             f"{theme.searchIcon} **Channel History Scan**\n"
-            f"└ Scan for gift codes in existing messages in a gift channel\n"
+            f"└ Scan for gift codes in existing messages in a gift channel\n\n"
+            f"{theme.redeemIcon} **Redemption Summary**\n"
+            f"└ Per-alliance: post a results summary in the channel after redemptions\n\n"
+            f"{theme.fidIcon} **Set Test ID**\n"
+            f"└ Player ID used to validate codes (blank = rotate alliance members)\n\n"
+            f"{theme.trashIcon} **Clear Redemption Cache**\n"
+            f"└ Wipe redemption records so codes can be re-redeemed\n"
             f"{theme.lowerDivider}"
         ),
         color=theme.emColor1
@@ -406,15 +412,19 @@ class CreateGiftCodeModal(discord.ui.Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         logger = self.cog.logger
-        await interaction.response.defer(ephemeral=True)
+        # thinking=True makes this a NEW ephemeral message; without it a modal submit
+        # just edits the menu the modal was opened from (ephemeral flag is ignored).
+        await interaction.response.defer(ephemeral=True, thinking=True)
 
         code = self.cog.clean_gift_code(self.giftcode.value)
         logger.info(f"[CreateGiftCodeModal] Code entered: {code}")
         final_embed = discord.Embed(title=f"{theme.giftIcon} Gift Code Creation Result")
 
-        # Check if code already exists
-        self.cog.cursor.execute("SELECT 1 FROM gift_codes WHERE giftcode = ?", (code,))
-        if self.cog.cursor.fetchone():
+        # A code we hold as 'invalid' that an admin re-adds is a reactivation candidate:
+        # re-validate it rather than bailing. Other stored statuses stay "already exists".
+        self.cog.cursor.execute("SELECT validation_status FROM gift_codes WHERE giftcode = ?", (code,))
+        row = self.cog.cursor.fetchone()
+        if row and row[0] != 'invalid':
             logger.info(f"[CreateGiftCodeModal] Code {code} already exists in DB.")
             final_embed.title = f"{theme.infoIcon} Gift Code Exists"
             final_embed.description = (
@@ -424,7 +434,8 @@ class CreateGiftCodeModal(discord.ui.Modal):
                 f"{theme.lowerDivider}\n"
             )
             final_embed.color = theme.emColor1
-        else: # Validate the code immediately
+        else: # Validate the code immediately (force a live re-probe for a reactivation candidate)
+            was_invalid = row is not None and row[0] == 'invalid'
             logger.info(f"[CreateGiftCodeModal] Validating code {code} before adding to DB.")
 
             validation_embed = discord.Embed(
@@ -434,7 +445,7 @@ class CreateGiftCodeModal(discord.ui.Modal):
             )
             await interaction.edit_original_response(embed=validation_embed)
 
-            is_valid, validation_msg = await self.cog.validate_gift_code_immediately(code, "button")
+            is_valid, validation_msg = await self.cog.validate_gift_code_immediately(code, "button", force=was_invalid)
 
             if is_valid: # Valid code - send to API and add to DB
                 logger.info(f"[CreateGiftCodeModal] Code '{code}' validated successfully.")
@@ -442,18 +453,33 @@ class CreateGiftCodeModal(discord.ui.Modal):
                 if hasattr(self.cog, 'api') and self.cog.api:
                     asyncio.create_task(self.cog.api.add_giftcode(code))
 
+                if was_invalid:
+                    # Genuine reactivation: clear old redemptions so members can claim again.
+                    try:
+                        self.cog.cursor.execute("DELETE FROM user_giftcodes WHERE giftcode = ?", (code,))
+                        self.cog.conn.commit()
+                        logger.info(f"[CreateGiftCodeModal] 🔄 REACTIVATION: '{code}' re-validated valid; cleared old redemption records")
+                    except Exception as e:
+                        logger.error(f"[CreateGiftCodeModal] Error clearing reactivation history for '{code}': {e}")
+
                 await self.cog._process_auto_use(code)
 
                 self.cog.cursor.execute("SELECT COUNT(*) FROM giftcodecontrol WHERE status = 1")
                 auto_count = self.cog.cursor.fetchone()[0]
 
-                final_embed.title = f"{theme.verifiedIcon} Gift Code Validated"
+                if auto_count:
+                    auto_redeem_line = f"{theme.refreshIcon} **Auto-redemption:** Queued for {auto_count} Alliances"
+                else:
+                    auto_redeem_line = f"{theme.refreshIcon} **Auto-redemption** is not enabled"
+
+                action_line = "Reactivated - re-validated and sent to API" if was_invalid else "Added to database and sent to API"
+                final_embed.title = f"{theme.verifiedIcon} Gift Code {'Reactivated' if was_invalid else 'Validated'}"
                 final_embed.description = (
                     f"**Gift Code Details**\n{theme.upperDivider}\n"
                     f"{theme.giftIcon} **Gift Code:** `{code}`\n"
                     f"{theme.verifiedIcon} **Status:** {validation_msg}\n"
-                    f"{theme.editListIcon} **Action:** Added to database and sent to API\n"
-                    f"{theme.refreshIcon} **Auto-redemption:** {'Queued for ' + str(auto_count) + ' alliance(s)' if auto_count else 'Disabled'}\n"
+                    f"{theme.editListIcon} **Action:** {action_line}\n"
+                    f"{auto_redeem_line}\n"
                     f"{theme.lowerDivider}\n"
                 )
                 final_embed.color = theme.emColor3
@@ -482,12 +508,17 @@ class CreateGiftCodeModal(discord.ui.Modal):
                     )
                     self.cog.conn.commit()
 
-                    final_embed.title = f"{theme.warnIcon} Gift Code Added (Pending)"
+                    # Re-check ASAP instead of waiting for the periodic loop.
+                    self.cog.schedule_revalidation(code, "button")
+
+                    from . import gift_redemption
+                    final_embed.title = f"{theme.warnIcon} Gift Code Added (Validating)"
                     final_embed.description = (
                         f"**Gift Code Details**\n{theme.upperDivider}\n"
                         f"{theme.giftIcon} **Gift Code:** `{code}`\n"
                         f"{theme.warnIcon} **Status:** {validation_msg}\n"
-                        f"{theme.editListIcon} **Action:** Added for later validation\n"
+                        f"{theme.editListIcon} **Action:** Saved - re-checking automatically\n"
+                        f"{gift_redemption.PENDING_REVALIDATION_NOTICE}\n"
                         f"{theme.lowerDivider}\n"
                     )
                     final_embed.color = theme.emColor4
@@ -845,6 +876,18 @@ class GiftView(discord.ui.View):
         await self.cog.show_settings_menu(interaction)
 
     @discord.ui.button(
+        label="Redemption History",
+        style=discord.ButtonStyle.secondary,
+        custom_id="redeem_history",
+        emoji=f"{theme.archiveIcon}",
+        row=1
+    )
+    async def redeem_history_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        await self.cog.show_redeem_results(interaction)
+
+    @discord.ui.button(
         label="Delete Gift Code",
         emoji=f"{theme.trashIcon}",
         style=discord.ButtonStyle.danger,
@@ -893,7 +936,7 @@ class SettingsMenuView(discord.ui.View):
         if not is_global:
             for child in self.children:
                 if isinstance(child, discord.ui.Button) and child.label in [
-                    "Redemption Priority"
+                    "Redemption Priority", "Set Test ID", "Clear Redemption Cache"
                 ]:
                     child.disabled = True
 
@@ -946,11 +989,59 @@ class SettingsMenuView(discord.ui.View):
         await self.cog.channel_history_scan(interaction)
 
     @discord.ui.button(
+        label="Redemption Summary",
+        style=discord.ButtonStyle.secondary,
+        custom_id="redemption_summary",
+        emoji=f"{theme.redeemIcon}",
+        row=1
+    )
+    async def redemption_summary_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        await self.cog.show_redemption_summary(interaction)
+
+    @discord.ui.button(
+        label="Set Test ID",
+        style=discord.ButtonStyle.secondary,
+        custom_id="set_test_fid",
+        emoji=f"{theme.fidIcon}",
+        row=1
+    )
+    async def set_test_fid_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        from .gift_settings import TestIDModal
+        await interaction.response.send_modal(TestIDModal(self.cog))
+
+    @discord.ui.button(
+        label="Clear Redemption Cache",
+        style=discord.ButtonStyle.danger,
+        custom_id="clear_redemption_cache",
+        emoji=f"{theme.trashIcon}",
+        row=2
+    )
+    async def clear_redemption_cache_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await check_interaction_user(interaction, self.original_user_id):
+            return
+        from .gift_settings import ClearCacheConfirmView
+        embed = discord.Embed(
+            title=f"{theme.warnIcon} Clear Redemption Cache",
+            description=(
+                f"{theme.upperDivider}\n"
+                f"This permanently deletes **all** gift code redemption records, letting users redeem every code again.\n\n"
+                f"{theme.warnIcon} This cannot be undone.\n"
+                f"{theme.lowerDivider}"
+            ),
+            color=theme.emColor2
+        )
+        await interaction.response.send_message(embed=embed, view=ClearCacheConfirmView(self.cog), ephemeral=True)
+
+    @discord.ui.button(
         label="Back",
         style=discord.ButtonStyle.secondary,
         custom_id="back_to_main",
         emoji=f"{theme.backIcon}",
-        row=2
+        row=3
     )
     async def back_to_main_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not await check_interaction_user(interaction, self.original_user_id):

--- a/main.py
+++ b/main.py
@@ -1303,6 +1303,16 @@ if __name__ == "__main__":
             conn_settings.execute("""CREATE INDEX IF NOT EXISTS idx_permission_audit_timestamp
                 ON permission_audit_log(timestamp DESC)""")
 
+            # Per-alliance opt-in channel summary posted after each redemption.
+            # No row = disabled (default). Buckets choose what the summary lists.
+            conn_settings.execute("""CREATE TABLE IF NOT EXISTS redemption_summary_settings (
+                alliance_id INTEGER PRIMARY KEY,
+                enabled INTEGER NOT NULL DEFAULT 0,
+                show_success INTEGER NOT NULL DEFAULT 0,
+                show_already INTEGER NOT NULL DEFAULT 0,
+                show_failed INTEGER NOT NULL DEFAULT 1
+            )""")
+
         with connections["conn_users"] as conn_users:
             conn_users.execute("""CREATE TABLE IF NOT EXISTS users (
                 fid INTEGER PRIMARY KEY,
@@ -1337,12 +1347,17 @@ if __name__ == "__main__":
             )""")
             
             conn_giftcode.execute("""CREATE TABLE IF NOT EXISTS user_giftcodes (
-                fid INTEGER, 
-                giftcode TEXT, 
-                status TEXT, 
+                fid INTEGER,
+                giftcode TEXT,
+                status TEXT,
+                last_attempt_at TEXT,
                 PRIMARY KEY (fid, giftcode),
                 FOREIGN KEY (giftcode) REFERENCES gift_codes (giftcode)
             )""")
+            # Upgrade path: per-account attempt timestamp for the redeem-results viewer.
+            uc_cols = [row[1] for row in conn_giftcode.execute("PRAGMA table_info(user_giftcodes)").fetchall()]
+            if "last_attempt_at" not in uc_cols:
+                conn_giftcode.execute("ALTER TABLE user_giftcodes ADD COLUMN last_attempt_at TEXT")
 
         with connections["conn_alliance"] as conn_alliance:
             conn_alliance.execute("""CREATE TABLE IF NOT EXISTS alliancesettings (


### PR DESCRIPTION
### Redemption Summary
- Posts a per-ally summary as up to three messages after each redemption run in the gift code channel
- Optional feature (off by default) accessible via /settings -> Gift Codes -> Settings -> Redemption Summary
- Choose which results should be posted - redeemed, already redeemed and/or failed
- Each summary post is silent and shows failures including IDs grouped by reason

### Redemption History
- New Redemption History button under /settings -> Gift Codes button opens a paginated screen showing which accounts redeemed/already redeemed/failed to redeem gift codes
- Provides a view into historical redemption records for bot admins, to complement the publicly posted records shown with the Redemption Summary feature

### Fixes
- Channel History Scan now auto-redeems and shares any valid codes it finds
- Changed confusing wording Pending -> Validating in the redemption embeds to clarify that codes are in the process of validation
- Rotate to alliance-member IDs when the primary ID is inconclusive
- Fix issue related to channel-discovered codes not being shared with the distribution API
- Fix issue with code reactivation not working properly (for previously-invalidated codes)