### PR TITLE
Bear Track: optional hunt time + auto Attendance event for bear

### DIFF
--- a/cogs/attendance.py
+++ b/cogs/attendance.py
@@ -53,6 +53,7 @@ _OCR_EVENT_DISPLAY = {
     "canyon_clash": ("Tri-Alliance Clash", "🔱"),
     "alliance_showdown": ("Alliance Brawl", "🛡️"),
     "power_rankings": ("Power Rankings", "📊"),
+    "bear": ("Bear Trap", "🐻"),
 }
 
 
@@ -2423,6 +2424,25 @@ class Attendance(commands.Cog):
                         (session_id,)
                     )
                     origin_row = cursor.fetchone()
+                    if origin_row and origin_row[0] == 'bear':
+                        notice = discord.Embed(
+                            title=f"{theme.warnIcon} Managed by Bear Track",
+                            description=(
+                                "This event is created from a Bear Trap submission. "
+                                "To change who took part or their damage, edit the hunt "
+                                "on the Bear side (Bear Damage review or records); the "
+                                "attendance event updates automatically."
+                            ),
+                            color=theme.emColor2,
+                        )
+                        back_view = self._create_back_view(
+                            lambda i: self.show_session_selection_for_marking(i, alliance_id)
+                        )
+                        if interaction.response.is_done():
+                            await interaction.edit_original_response(embed=notice, view=back_view)
+                        else:
+                            await interaction.response.edit_message(embed=notice, view=back_view)
+                        return
                     if origin_row and origin_row[0] == 'ocr':
                         ocr_cog = self.bot.get_cog("AttendanceOCR")
                         opened = False

--- a/cogs/attendance_ocr_parsers.py
+++ b/cogs/attendance_ocr_parsers.py
@@ -1467,6 +1467,53 @@ def delete_session(session_id: str) -> None:
         conn.commit()
 
 
+def _bear_session_id(hunt_id) -> str:
+    return f"bear-{hunt_id}"
+
+
+def _bear_trap_label(hunting_trap) -> str:
+    return {1: "Trap 1", 2: "Trap 2", 3: "Both Traps"}.get(
+        int(hunting_trap), f"Trap {hunting_trap}")
+
+
+def sync_bear_attendance_event(*, alliance_id, hunt_id, date, hunting_trap,
+                               event_time, alliance_name, participants) -> None:
+    """Create or replace the attendance event mirroring one bear hunt. Bear is
+    the source of truth: the event's records are fully rewritten to the current
+    participants (all 'present', points=damage). event_time may be None."""
+    session_id = _bear_session_id(hunt_id)
+    trap_label = _bear_trap_label(hunting_trap)
+    session_name = f"{trap_label} - {date}"
+    with sqlite3.connect(_ATT_DB, timeout=30.0) as conn:
+        conn.execute("DELETE FROM attendance_records WHERE session_id = ?", (session_id,))
+        conn.execute(
+            "INSERT OR REPLACE INTO attendance_sessions "
+            "(session_id, event_type, event_date, event_subtype, alliance_id, "
+            " awaiting_result, origin, event_time) "
+            "VALUES (?, 'bear', ?, ?, ?, 0, 'bear', ?)",
+            (session_id, date, trap_label, alliance_id, event_time),
+        )
+        for p in participants:
+            conn.execute(
+                "INSERT INTO attendance_records "
+                "(session_id, session_name, event_type, event_date, player_id, "
+                " player_name, alliance_id, alliance_name, status, points, event_subtype) "
+                "VALUES (?, ?, 'bear', ?, ?, ?, ?, ?, 'present', ?, ?)",
+                (session_id, session_name, date, str(p['fid']), p['name'],
+                 str(alliance_id), alliance_name or "", int(p['damage']), trap_label),
+            )
+        conn.commit()
+
+
+def delete_bear_attendance_event(*, hunt_id) -> None:
+    """Remove the attendance event mirroring a deleted bear hunt."""
+    session_id = _bear_session_id(hunt_id)
+    with sqlite3.connect(_ATT_DB, timeout=30.0) as conn:
+        conn.execute("DELETE FROM attendance_records WHERE session_id = ?", (session_id,))
+        conn.execute("DELETE FROM attendance_sessions WHERE session_id = ?", (session_id,))
+        conn.commit()
+
+
 def _unmatched_id_floor(session_id: str) -> int:
     """Most-negative existing player_id for this session, or 0 if none. Callers
     decrement from this to allocate a fresh per-session placeholder id."""

--- a/cogs/attendance_ocr_review.py
+++ b/cogs/attendance_ocr_review.py
@@ -457,9 +457,9 @@ class EventReviewView(discord.ui.View):
             absent = is_result and self.zero_is_absent and not r["value"]
             icon = theme.deniedIcon if absent else _STATUS_ICON.get(r["status"], "")
             if r["status"] in ("auto", "manual") and r["fid"]:
-                player = f"`{_isolate_rtl(r['nickname'])}` · `{r['fid']}`"
+                player = f"`{_isolate_rtl(r['nickname'])}` (`{r['fid']}`)"
             elif r["status"] in ("likely", "review") and r["fid"]:
-                player = f"`{_isolate_rtl(r['nickname'])}` ({r['status']}) · `{r['fid']}`"
+                player = f"`{_isolate_rtl(r['nickname'])}` ({r['status']}) (`{r['fid']}`)"
             else:
                 player = f"`{_isolate_rtl(r['name'])}` — no match"
             tail = "`Absent`" if absent else f"`{_format_int(r['value'])}`"

--- a/cogs/attendance_report.py
+++ b/cogs/attendance_report.py
@@ -11,7 +11,7 @@ import csv
 import io
 from io import BytesIO
 import os
-from .attendance import SessionSelectView
+from .attendance import SessionSelectView, event_type_display
 from .pimp_my_bot import theme
 
 logger = logging.getLogger('bot')
@@ -312,7 +312,7 @@ class AttendanceReport(commands.Cog):
         # Write metadata
         writer.writerow(['Session Name:', session_info['session_name']])
         writer.writerow(['Alliance:', session_info['alliance_name']])
-        writer.writerow(['Event Type:', session_info.get('event_type', 'Other')])
+        writer.writerow(['Event Type:', event_type_display(session_info.get('event_type') or 'Other')[0]])
         if session_info.get('event_date'):
             writer.writerow(['Event Date:', session_info['event_date'].split('T')[0] if isinstance(session_info['event_date'], str) else session_info['event_date']])
         writer.writerow(['Export Date:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
@@ -346,7 +346,7 @@ class AttendanceReport(commands.Cog):
         # Write metadata
         writer.writerow(['Session Name:', session_info['session_name']])
         writer.writerow(['Alliance:', session_info['alliance_name']])
-        writer.writerow(['Event Type:', session_info.get('event_type', 'Other')])
+        writer.writerow(['Event Type:', event_type_display(session_info.get('event_type') or 'Other')[0]])
         if session_info.get('event_date'):
             writer.writerow(['Event Date:', session_info['event_date'].split('T')[0] if isinstance(session_info['event_date'], str) else session_info['event_date']])
         writer.writerow(['Export Date:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
@@ -440,7 +440,7 @@ class AttendanceReport(commands.Cog):
     
     <div class="stats">
         <h3>Summary</h3>
-        <p><strong>Event Type:</strong> {session_info.get('event_type', 'Other')}</p>
+        <p><strong>Event Type:</strong> {event_type_display(session_info.get('event_type') or 'Other')[0]}</p>
         {'<p><strong>Event Date:</strong> ' + (session_info['event_date'].split('T')[0] if isinstance(session_info.get('event_date'), str) else str(session_info.get('event_date', ''))) + '</p>' if session_info.get('event_date') else ''}
         <p><strong>Export Date:</strong> {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
         <p><strong>Total Players:</strong> {session_info['total_players']}</p>
@@ -585,7 +585,7 @@ class AttendanceReport(commands.Cog):
                     f"**Format:** {format_name}\n"
                     f"**Alliance:** {session_info['alliance_name']}\n"
                     f"**Session:** {session_info['session_name']}\n"
-                    f"**Event Type:** {session_info.get('event_type', 'Other')}\n"
+                    f"**Event Type:** {event_type_display(session_info.get('event_type') or 'Other')[0]}\n"
                     f"**Total Records:** {session_info['total_players']}",
                     file=file
                 )
@@ -844,7 +844,7 @@ class AttendanceReport(commands.Cog):
                 # Format title with event type and date
                 title_text = f'Attendance Report - {alliance_name} | {session_name}'
                 if event_type:
-                    title_text += f' [{event_type}]'
+                    title_text += f' [{event_type_display(event_type)[0]}]'
                 if event_date:
                     if isinstance(event_date, str):
                         date_str = event_date.split('T')[0] if 'T' in event_date else event_date.split()[0]
@@ -893,7 +893,7 @@ class AttendanceReport(commands.Cog):
             embed_title = f"{theme.chartIcon} Attendance Report - {alliance_name}"
             description_text = f"**Session:** {session_name}"
             if event_type:
-                description_text += f" [{event_type}]"
+                description_text += f" [{event_type_display(event_type)[0]}]"
             description_text += f"\n**Total Marked:** {len(records)} players"
             
             embed = discord.Embed(
@@ -1196,7 +1196,7 @@ class AttendanceReport(commands.Cog):
             report_sections.append(f"{theme.chartIcon} **SUMMARY**")
             session_line = f"**Session:** {session_name}"
             if event_type:
-                session_line += f" [{event_type}]"
+                session_line += f" [{event_type_display(event_type)[0]}]"
             report_sections.append(session_line)
             report_sections.append(f"**Alliance:** {alliance_name}")
             date_str = "N/A"
@@ -1214,8 +1214,6 @@ class AttendanceReport(commands.Cog):
             report_sections.append(f"**Date:** {date_str}")
             report_sections.append(f"**Total Marked:** {len(records)} players")
             report_sections.append(f"**Present:** {present_count} | **Absent:** {absent_count}")
-            if session_id:
-                report_sections.append(f"**Session ID:** {session_id}")
             report_sections.append("")
             
             # Player details section
@@ -1319,10 +1317,7 @@ class AttendanceReport(commands.Cog):
 
                 # Add footer only to last embed
                 if idx == len(embeds) - 1:
-                    if session_id:
-                        embed.set_footer(text=f"Session ID: {session_id} | {sort_footer}")
-                    else:
-                        embed.set_footer(text=sort_footer)
+                    embed.set_footer(text=sort_footer)
 
                 discord_embeds.append(embed)
 

--- a/cogs/bear_track.py
+++ b/cogs/bear_track.py
@@ -147,6 +147,14 @@ os.makedirs("db", exist_ok=True)
 BEAR_DB_PATH = "db/bear_data.sqlite"
 
 
+def _ensure_bear_hunts_event_time(conn):
+    """Idempotently add the optional event_time column to bear_hunts."""
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(bear_hunts)")]
+    if "event_time" not in cols:
+        conn.execute("ALTER TABLE bear_hunts ADD COLUMN event_time TEXT")
+        conn.commit()
+
+
 def init_bear_database():
     """Initialize bear_hunts + bear_player_damage tables."""
     conn = sqlite3.connect(BEAR_DB_PATH, timeout=30.0)
@@ -164,6 +172,7 @@ def init_bear_database():
             UNIQUE (alliance_id, date, hunting_trap)
         )
     """)
+    _ensure_bear_hunts_event_time(conn)
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS bear_player_damage (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -3338,6 +3347,7 @@ class BearTrack(commands.Cog):
             'rallies': int(primary_event.rallies_value)
                 if primary_event.rallies_value and primary_event.rallies_value.isdigit() else None,
             'total_damage': damage_int or 0,
+            'event_time': None,
         }
         sorted_rows = sorted(
             merged_rows.values(),
@@ -3451,6 +3461,7 @@ class BearTrack(commands.Cog):
             'hunting_trap': int(hunting_trap),
             'rallies': int(rallies) if rallies else None,
             'total_damage': int(total_damage) if total_damage else 0,
+            'event_time': None,
         }
 
         review = BearHuntReviewView(
@@ -4003,10 +4014,13 @@ class BearHuntReviewView(discord.ui.View):
             value=str(self.hunt_meta['rallies']) if self.hunt_meta['rallies'] is not None else "-",
             inline=True,
         )
+        # Time (when set) sits under Date; Total Alliance Damage sits to its right.
+        if self.hunt_meta.get('event_time'):
+            embed.add_field(name="Time (UTC)", value=self.hunt_meta['event_time'], inline=True)
         embed.add_field(
             name="Total Alliance Damage",
             value=format_damage_for_embed(self.hunt_meta['total_damage']) if self.hunt_meta['total_damage'] is not None else "-",
-            inline=False,
+            inline=True,
         )
 
         if not self.rows:
@@ -4495,8 +4509,35 @@ class BearHuntReviewView(discord.ui.View):
         await self.refresh(interaction)
 
 
+def _normalize_event_time(raw):
+    """Blank -> None; a valid H:MM/HH:MM -> zero-padded 'HH:MM'; else ValueError."""
+    s = (raw or "").strip()
+    if not s:
+        return None
+    m = re.fullmatch(r'(\d{1,2}):(\d{2})', s)
+    if not m:
+        raise ValueError("time must be HH:MM")
+    hh, mm = int(m.group(1)), int(m.group(2))
+    if hh > 23 or mm > 59:
+        raise ValueError("time out of range")
+    return f"{hh:02d}:{mm:02d}"
+
+
+def _bear_participants(player_rows):
+    """Matched rows only (fid present) as attendance participants."""
+    out = []
+    for r in (player_rows or []):
+        fid = r.get('fid')
+        if not fid:
+            continue
+        out.append({'fid': fid,
+                    'name': r.get('nickname') or r.get('name') or '',
+                    'damage': int(r['damage'])})
+    return out
+
+
 class EditHeaderModal(discord.ui.Modal):
-    """Edit the hunt-level header fields (date / trap / rallies / total)."""
+    """Edit the hunt-level header fields (date / trap / rallies / total / time)."""
 
     def __init__(self, review_view: BearHuntReviewView):
         super().__init__(title="Edit Bear Hunt Info")
@@ -4520,7 +4561,13 @@ class EditHeaderModal(discord.ui.Modal):
             default=format_damage_for_embed(meta['total_damage']) if meta['total_damage'] else "",
             max_length=30,
         )
-        for item in (self.date_input, self.trap_input, self.rallies_input, self.total_input):
+        self.time_input = discord.ui.TextInput(
+            label="Time (UTC, optional) - HH:MM",
+            default=meta.get('event_time') or "",
+            required=False, max_length=5,
+        )
+        for item in (self.date_input, self.trap_input, self.rallies_input,
+                     self.total_input, self.time_input):
             self.add_item(item)
 
     async def on_submit(self, interaction):
@@ -4548,11 +4595,20 @@ class EditHeaderModal(discord.ui.Modal):
                     f"{theme.deniedIcon} Rallies must be a whole number.", ephemeral=True,
                 )
                 return
+        try:
+            event_time = _normalize_event_time(self.time_input.value)
+        except ValueError:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} Time must be HH:MM (24-hour UTC), or blank.",
+                ephemeral=True,
+            )
+            return
         self.review_view.hunt_meta = {
             'date': date_norm,
             'hunting_trap': trap,
             'rallies': rallies,
             'total_damage': bear_damage(self.total_input.value),
+            'event_time': event_time,
         }
         await self.review_view.refresh(interaction)
 
@@ -5530,6 +5586,12 @@ class BearDamageEditView(discord.ui.View):
             await interaction.response.send_message(
                 f"{theme.deniedIcon} Failed to delete hunt.", ephemeral=True)
             return
+        try:
+            from .attendance_ocr_parsers import delete_bear_attendance_event
+            delete_bear_attendance_event(hunt_id=self.selected_record_id)
+        except Exception as e:
+            logger.error(f"Bear attendance delete failed: {e}")
+            print(f"[ERROR] Bear attendance delete failed: {e}")
         self.selected_record_id = None
         self.date = self.hunting_trap = self.rallies = self.total_damage = None
         self.players = []
@@ -7275,13 +7337,14 @@ class DataSubmit:
             hunting_trap=hunt_meta['hunting_trap'],
             rallies=hunt_meta.get('rallies'),
             total_damage=hunt_meta.get('total_damage') or 0,
+            event_time=hunt_meta.get('event_time'),
             player_rows=player_rows,
             alliance_id=alliance_id, alliance_name=alliance_name,
             existing_hunt_id=existing_hunt_id,
         )
 
     async def _persist_hunt_and_render(self, interaction, *, date, hunting_trap, rallies,
-                                       total_damage, player_rows=None,
+                                       total_damage, event_time=None, player_rows=None,
                                        alliance_id=None, alliance_name=None,
                                        existing_hunt_id=None):
         """Insert one hunt row (and any provided player rows), then build
@@ -7331,8 +7394,8 @@ class DataSubmit:
                     # Edit in place: keep the hunt record, refresh summary + rows.
                     hunt_id = existing[0]
                     self.bear_cursor.execute(
-                        "UPDATE bear_hunts SET rallies=?, total_damage=? WHERE id=?",
-                        (rallies, total_damage, hunt_id),
+                        "UPDATE bear_hunts SET rallies=?, total_damage=?, event_time=? WHERE id=?",
+                        (rallies, total_damage, event_time, hunt_id),
                     )
                     self.bear_cursor.execute(
                         "DELETE FROM bear_player_damage WHERE hunt_id=?", (hunt_id,)
@@ -7341,9 +7404,9 @@ class DataSubmit:
             if not edited:
                 try:
                     self.bear_cursor.execute(
-                        "INSERT INTO bear_hunts (alliance_id, date, hunting_trap, rallies, total_damage) "
-                        "VALUES (?, ?, ?, ?, ?)",
-                        (alliance_id, date, hunting_trap, rallies, total_damage),
+                        "INSERT INTO bear_hunts (alliance_id, date, hunting_trap, rallies, total_damage, event_time) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (alliance_id, date, hunting_trap, rallies, total_damage, event_time),
                     )
                     hunt_id = self.bear_cursor.lastrowid
                 except sqlite3.IntegrityError:
@@ -7390,6 +7453,21 @@ class DataSubmit:
                 learn_alias(alliance_id, name, fid)
             except Exception as e:
                 logger.warning(f"Bear OCR: post-commit learn_alias failed for {name!r}: {e}")
+
+        # Mirror the saved hunt into an attendance event. Best-effort: a sync
+        # failure must never roll back the saved hunt.
+        if player_rows is not None:
+            try:
+                from .attendance_ocr_parsers import sync_bear_attendance_event
+                sync_bear_attendance_event(
+                    alliance_id=alliance_id, hunt_id=hunt_id, date=date,
+                    hunting_trap=hunting_trap, event_time=event_time,
+                    alliance_name=alliance_name,
+                    participants=_bear_participants(player_rows),
+                )
+            except Exception as e:
+                logger.error(f"Bear attendance sync failed for hunt {hunt_id}: {e}")
+                print(f"[ERROR] Bear attendance sync failed for hunt {hunt_id}: {e}")
 
         title_suffix = "Updated Submission" if edited else "Latest Submission"
         if player_rows:


### PR DESCRIPTION
Bear hunts can now carry an optional UTC time, and every bear submit creates or updates a matching Attendance event so bear participation shows in Attendance history, reports, and points.

## Changes

- **Optional hunt time** - set it in the Edit Hunt modal, blank saves as before.
- **Auto Attendance event** per hunt, keyed on `bear-<hunt_id>` and rewritten on each submit; hunt delete removes it. Matched players only, all are marked `present`, and `points = damage`.
- New `sync_bear_attendance_event` / `delete_bear_attendance_event` helpers own all attendance-DB writes; bear calls them after its own commit, best-effort (a sync failure never rolls back the hunt).
- Bear events are `origin='bear'`, set as read-only in the Attendance marking UI, and display as "Bear Trap" 🐻.
- Report/chart/exports show friendly event labels ("Bear Trap", "Tri-Alliance Clash") instead of raw keys
- Dropped the unused Session ID from the report.