### PR TITLE
Fix latent crashes, connection leaks, and wrong-type comparisons

### DIFF
--- a/cogs/alliance.py
+++ b/cogs/alliance.py
@@ -191,8 +191,8 @@ class Alliance(commands.Cog):
     async def settings(self, interaction: discord.Interaction):
         try:
             if interaction.guild is not None: # Check bot permissions only if in a guild
-                perm_check = interaction.guild.get_member(interaction.client.user.id)
-                if not perm_check.guild_permissions.administrator:
+                perm_check = interaction.guild.me
+                if perm_check is None or not perm_check.guild_permissions.administrator:
                     await interaction.response.send_message(
                         f"Beeb boop {theme.robotIcon} I need **Administrator** permissions to function. "
                         "Go to server settings --> Roles --> find my role --> scroll down and turn on Administrator", 

--- a/cogs/alliance_history.py
+++ b/cogs/alliance_history.py
@@ -626,7 +626,14 @@ class AllianceHistory(commands.Cog):
             with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                 cursor = alliance_db.cursor()
                 cursor.execute("SELECT alliance_id FROM alliance_list WHERE name = ?", (alliance_name,))
-                alliance_id = cursor.fetchone()[0]
+                row = cursor.fetchone()
+                if not row:
+                    await interaction.followup.send(
+                        f"{theme.deniedIcon} Alliance **{alliance_name}** not found.",
+                        ephemeral=True
+                    )
+                    return
+                alliance_id = row[0]
 
             with sqlite3.connect('db/users.sqlite') as users_db:
                 cursor = users_db.cursor()
@@ -636,6 +643,13 @@ class AllianceHistory(commands.Cog):
                     WHERE alliance = ?
                 """, (alliance_id,))
                 members = {fid: name for fid, name in cursor.fetchall()}
+
+            if not members:
+                await interaction.followup.send(
+                    f"No level changes found in the last {human_readable_time} for {alliance_name}.",
+                    ephemeral=True
+                )
+                return
 
             with sqlite3.connect('db/changes.sqlite', timeout=30.0) as conn:
                 cursor = conn.cursor()
@@ -683,7 +697,14 @@ class AllianceHistory(commands.Cog):
             with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                 cursor = alliance_db.cursor()
                 cursor.execute("SELECT alliance_id FROM alliance_list WHERE name = ?", (alliance_name,))
-                alliance_id = cursor.fetchone()[0]
+                row = cursor.fetchone()
+                if not row:
+                    await interaction.followup.send(
+                        f"{theme.deniedIcon} Alliance **{alliance_name}** not found.",
+                        ephemeral=True
+                    )
+                    return
+                alliance_id = row[0]
 
             with sqlite3.connect('db/users.sqlite') as users_db:
                 cursor = users_db.cursor()
@@ -693,6 +714,13 @@ class AllianceHistory(commands.Cog):
                     WHERE alliance = ?
                 """, (alliance_id,))
                 members = {fid: name for fid, name in cursor.fetchall()}
+
+            if not members:
+                await interaction.followup.send(
+                    f"No nickname changes found in the last {human_readable_time} for {alliance_name}.",
+                    ephemeral=True
+                )
+                return
 
             with sqlite3.connect('db/changes.sqlite', timeout=30.0) as conn:
                 cursor = conn.cursor()

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -200,7 +200,7 @@ class MemberListView(discord.ui.View):
         ("Name A→Z",  lambda m: m['nickname'].casefold(),                      False),
         ("Name Z→A",  lambda m: m['nickname'].casefold(),                      True),
         ("ID \u2191",      lambda m: m['fid'],                                       False),
-        ("State \u2191",   lambda m: (m['kid'], -m['furnace_lv']),                  False),
+        ("State \u2191",   lambda m: (m['kid'] is None, m['kid'] or 0, -m['furnace_lv']), False),
     ]
 
     def __init__(self, members, alliance_id, alliance_name, cog, author_id):
@@ -2566,7 +2566,8 @@ class IDSearchModal(discord.ui.Modal):
                 with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                     cursor = alliance_db.cursor()
                     cursor.execute("SELECT name FROM alliance_list WHERE alliance_id = ?", (current_alliance_id,))
-                    current_alliance_name = cursor.fetchone()[0]
+                    row = cursor.fetchone()
+                    current_alliance_name = row[0] if row else "Unknown"
 
                 # Handle remove context
                 if self.context == "remove":
@@ -2656,7 +2657,7 @@ class IDSearchModal(discord.ui.Modal):
                 # Handle giftcode context - validate permission and invoke callback with alliance
                 if self.context == "giftcode":
                     # Check if user has permission to manage this alliance
-                    has_permission = any(aid == current_alliance_id for aid, _, _ in self.alliances)
+                    has_permission = any(str(aid) == str(current_alliance_id) for aid, _, _ in self.alliances)
                     if not has_permission:
                         await interaction.response.send_message(
                             f"{theme.deniedIcon} You don't have permission to manage the alliance this member belongs to.",
@@ -2693,7 +2694,7 @@ class IDSearchModal(discord.ui.Modal):
                             description=f"ID: {alliance_id}",
                             emoji=theme.allianceIcon
                         ) for alliance_id, name, _ in self.alliances
-                        if alliance_id != current_alliance_id
+                        if str(alliance_id) != str(current_alliance_id)
                     ]
                 )
 

--- a/cogs/attendance_ocr_review.py
+++ b/cogs/attendance_ocr_review.py
@@ -599,7 +599,7 @@ class EventReviewView(discord.ui.View):
             return bits
 
         unmatched = sum(1 for r in self.all_rows if not r["fid"])
-        low_conf = sum(1 for r in self.all_rows if r["status"] == "review")
+        low_conf = sum(1 for r in self.all_rows if r["status"] in ("likely", "review"))
         absent_count = self._would_be_absent_count()
         if unmatched:
             bits.append(f"{unmatched} unmatched — use Edit a player row to assign")
@@ -1657,7 +1657,8 @@ class _EditRowModal(discord.ui.Modal):
 
     async def on_submit(self, interaction: discord.Interaction):
         if not self.player_input.value.strip():
-            del self.bucket[self.local_idx]
+            if self.local_idx is not None and self.local_idx < len(self.bucket):
+                del self.bucket[self.local_idx]
             await self.view._save_edit(interaction)
             return
         value = _parse_value_input(self.value_input.value)
@@ -1669,10 +1670,12 @@ class _EditRowModal(discord.ui.Modal):
 
         fid, nickname, status, note = await _resolve_player_field(
             interaction, self.view, self.player_input.value)
-        # Update in place so the original OCR name (alias key) and _kind survive.
-        self.bucket[self.local_idx].update(
-            {"value": value, "fid": fid, "nickname": nickname, "status": status})
-        displaced = self.view._apply_fid_collision(self.bucket, self.local_idx, fid) if fid else []
+        displaced = []
+        if self.local_idx is not None and self.local_idx < len(self.bucket):
+            # Update in place so the original OCR name (alias key) and _kind survive.
+            self.bucket[self.local_idx].update(
+                {"value": value, "fid": fid, "nickname": nickname, "status": status})
+            displaced = self.view._apply_fid_collision(self.bucket, self.local_idx, fid) if fid else []
         await self.view._save_edit(interaction)
         messages = []
         if note and self.player_input.value.strip() != self._orig_player:

--- a/cogs/gift_operationsapi.py
+++ b/cogs/gift_operationsapi.py
@@ -325,6 +325,8 @@ class GiftCodeAPI:
                                                     # Re-test soon instead of waiting for the 2h loop.
                                                     gift_operations.schedule_revalidation(code, "api")
                                             else:
+                                                # Cog missing: validity is unknown, so is_valid stays None.
+                                                is_valid = None
                                                 self.logger.error("GiftOperations cog not found for validation!")
                                                 validation_status = f"{theme.deniedIcon} Error"
                                                 auto_alliances = []

--- a/cogs/gift_redemption.py
+++ b/cogs/gift_redemption.py
@@ -816,8 +816,8 @@ def set_summary_settings(cog, alliance_id, *, enabled=None, success=None, alread
     cog.settings_conn.commit()
 
 
-def _summary_names_block(names, limit=1024) -> str:
-    """One name per line, truncated to fit `limit` chars, with an overflow pointer to Redemption History."""
+def _summary_names_block(names, limit=1024, overflow="see Redemption History") -> str:
+    """One name per line, truncated to fit `limit` chars, with an overflow pointer."""
     out, used = [], 0
     for n in names:
         need = len(n) + 2  # + newline + LRM
@@ -830,7 +830,7 @@ def _summary_names_block(names, limit=1024) -> str:
     text = "\n".join(out)
     more = len(names) - len(out)
     if more > 0:
-        text += f"\n…and {more} more - see Redemption History"
+        text += f"\n…and {more} more - {overflow}"
     return text
 
 
@@ -1415,7 +1415,8 @@ async def post_removal_summary(cog, removals):
             if channel is None:
                 continue
             listed = _summary_names_block(
-                [f"{_iso(nick)} (`{fid}`)" for fid, nick in members], 3800)
+                [f"{_iso(nick)} (`{fid}`)" for fid, nick in members], 3800,
+                overflow="see the bot log")
             embed = discord.Embed(
                 title=f"{theme.membersIcon} Member Auto-removed ({len(members)})",
                 description=(

--- a/cogs/gift_redemption.py
+++ b/cogs/gift_redemption.py
@@ -256,9 +256,12 @@ async def _record_batch_result(cog, batch_id, alliance_id, success):
     alliances[alliance_id]['codes_completed'] = alliances[alliance_id].get('codes_completed', 0) + 1
     codes_done = alliances[alliance_id]['codes_completed']
 
+    if not success:
+        alliances[alliance_id]['had_error'] = True
+    had_error = alliances[alliance_id].get('had_error', False)
     if codes_done >= total_codes:
-        alliances[alliance_id]['status'] = 'completed' if success else 'error'
-    elif success:
+        alliances[alliance_id]['status'] = 'completed' if not had_error else 'error'
+    elif not had_error:
         alliances[alliance_id]['status'] = 'processing'
     else:
         alliances[alliance_id]['status'] = 'error'
@@ -1415,8 +1418,7 @@ async def post_removal_summary(cog, removals):
             if channel is None:
                 continue
             listed = _summary_names_block(
-                [f"{_iso(nick)} (`{fid}`)" for fid, nick in members], 3800,
-                overflow="see the bot log")
+                [f"{_iso(nick)} (`{fid}`)" for fid, nick in members], 3800)
             embed = discord.Embed(
                 title=f"{theme.membersIcon} Member Auto-removed ({len(members)})",
                 description=(

--- a/cogs/minister_archive.py
+++ b/cogs/minister_archive.py
@@ -782,10 +782,6 @@ class MinisterArchive(commands.Cog):
     async def show_archive_appointments(self, interaction: discord.Interaction, archive_id: int, appointment_type: str):
         """Show detailed appointment list for a specific activity day in an archive"""
         try:
-            # Get alliance database connection
-            alliance_conn = sqlite3.connect('db/alliance.sqlite')
-            alliance_cursor = alliance_conn.cursor()
-
             # Get appointments for this archive and appointment type
             self.svs_cursor.execute("""
                 SELECT time, fid, nickname, alliance
@@ -811,14 +807,11 @@ class MinisterArchive(commands.Cog):
                 view.add_item(back_button)
 
                 await interaction.response.edit_message(embed=embed, view=view)
-                alliance_conn.close()
                 return
 
             # Create view with appointments
             view = ArchiveAppointmentsView(self.bot, self, archive_id, appointment_type, appointments)
             await self.update_appointments_embed(interaction, view)
-
-            alliance_conn.close()
 
         except Exception as e:
             logger.error(f"Error loading appointments: {e}")

--- a/cogs/minister_menu.py
+++ b/cogs/minister_menu.py
@@ -582,15 +582,15 @@ class MinisterChannelView(discord.ui.View):
         log_channel_id = await minister_schedule_cog.get_channel_id(log_context)
         log_guild = await minister_schedule_cog.get_log_guild(interaction.guild)
 
-        channel = log_guild.get_channel(channel_id)
-        log_channel = log_guild.get_channel(log_channel_id)
-
         if not log_guild:
             await interaction.response.send_message(
                 "Could not find the minister log server. Make sure the bot is in that server.\n\nIf issue persists, run the `/settings` command --> Other Features --> Minister Scheduling --> Delete Server ID and try again in the desired server",
                 ephemeral=True
             )
             return
+
+        channel = log_guild.get_channel(channel_id)
+        log_channel = log_guild.get_channel(log_channel_id)
 
         if not channel or not log_channel:
             await interaction.response.send_message(
@@ -1598,6 +1598,13 @@ class MinisterMenu(commands.Cog):
             return
 
         log_guild = await minister_schedule_cog.get_log_guild(interaction.guild)
+        if not log_guild:
+            await interaction.response.send_message(
+                "Could not find the minister log server. Make sure the bot is in that server.\n\nIf issue persists, run the `/settings` command --> Other Features --> Minister Scheduling --> Delete Server ID and try again in the desired server",
+                ephemeral=True
+            )
+            return
+
         log_channel_id = await minister_schedule_cog.get_channel_id("minister log channel")
         log_channel = log_guild.get_channel(log_channel_id)
 

--- a/cogs/minister_schedule.py
+++ b/cogs/minister_schedule.py
@@ -827,7 +827,7 @@ class MinisterSchedule(commands.Cog):
                 color=theme.emColor3
             )
             embed.set_thumbnail(url=avatar_image)
-            embed.set_author(name=f"Added by {interaction.user.display_name}", icon_url=interaction.user.avatar.url)
+            embed.set_author(name=f"Added by {interaction.user.display_name}", icon_url=interaction.user.avatar.url if interaction.user.avatar else None)
 
             await self.send_embed_to_channel(embed)
             await interaction.followup.send(f"Added {nickname} to {time}")
@@ -967,7 +967,7 @@ class MinisterSchedule(commands.Cog):
                 color=theme.emColor2
             )
             embed.set_thumbnail(url=avatar_image)
-            embed.set_author(name=f"Removed by {interaction.user.display_name}", icon_url=interaction.user.avatar.url)
+            embed.set_author(name=f"Removed by {interaction.user.display_name}", icon_url=interaction.user.avatar.url if interaction.user.avatar else None)
 
             await self.send_embed_to_channel(embed)
             await interaction.followup.send(f"Removed {nickname}")
@@ -1093,7 +1093,7 @@ class MinisterSchedule(commands.Cog):
                         description=f"All appointments for {appointment_type} have been successfully removed.",
                         color=theme.emColor2
                     )
-                    embed.set_author(name=f"Cleared by {interaction.user.display_name}", icon_url=interaction.user.avatar.url)
+                    embed.set_author(name=f"Cleared by {interaction.user.display_name}", icon_url=interaction.user.avatar.url if interaction.user.avatar else None)
 
                     await self.send_embed_to_channel(embed)
                     await interaction.followup.send(f"{theme.verifiedIcon} Deleted all {appointment_type} appointments.")

--- a/cogs/notification_editor.py
+++ b/cogs/notification_editor.py
@@ -70,13 +70,15 @@ def format_repeat_interval(repeat_minutes, notification_id=None) -> str:
             return "Custom Days"
 
         conn = sqlite3.connect("db/beartime.sqlite")
-        cursor = conn.cursor()
-        cursor.execute("""
-            SELECT weekday FROM notification_days
-            WHERE notification_id = ?
-        """, (notification_id,))
-        rows = cursor.fetchall()
-        conn.close()
+        try:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT weekday FROM notification_days
+                WHERE notification_id = ?
+            """, (notification_id,))
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
 
         weekday_names = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
         day_set = set()
@@ -939,113 +941,128 @@ class NotificationEditor(commands.Cog):
             return
 
         conn = sqlite3.connect("db/beartime.sqlite")
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT channel_id, hour, minute, description, mention_type, repeat_minutes, next_notification, timezone, notification_type, event_type FROM bear_notifications WHERE id = ?",
-            (notification_id,))
-        result = cursor.fetchone()
-
-        if not result:
-            await interaction.response.send_message(f"{theme.deniedIcon} Notification ID not found.", ephemeral=True)
-            return
-
-        channel_id, hours, minutes, description, mention, repeat, next_notification, timezone, notification_type, event_type = result
-        if "EMBED_MESSAGE" in description:
+        try:
+            cursor = conn.cursor()
             cursor.execute(
-                "SELECT title, description, color, image_url, thumbnail_url, footer, author, mention_message FROM bear_notification_embeds WHERE notification_id = ?",
+                "SELECT channel_id, hour, minute, description, mention_type, repeat_minutes, next_notification, timezone, notification_type, event_type FROM bear_notifications WHERE id = ?",
                 (notification_id,))
-            embed_results = cursor.fetchone()
-            title, embed_description, color, image_url, thumbnail_url, footer, author, mention_message = embed_results
+            result = cursor.fetchone()
 
-            view = EmbedDataView(self, notification_id, title, embed_description, color, image_url, thumbnail_url,
-                                 footer, author, mention_message, event_type, hours, minutes, next_notification)
-
-            # Replace variables for initial display
-            embed = discord.Embed(
-                title=view._replace_variables(title),
-                description=view._replace_variables(embed_description),
-                color=color,
-            )
-            if footer:
-                embed.set_footer(text=view._replace_variables(footer))
-            if author:
-                embed.set_author(name=view._replace_variables(author))
-            if image_url:
-                embed.set_image(url=image_url)
-            if thumbnail_url:
-                embed.set_thumbnail(url=thumbnail_url)
-
-            mention_preview = view._replace_variables(mention_message) if mention_message else ""
-
-            await interaction.response.defer()
-            if original_message:
-                await original_message.edit(content=mention_preview, embed=embed, view=view)
-                message = original_message
-            else:
-                message = await interaction.followup.send(content=mention_preview, embed=embed, view=view,
-                                                          ephemeral=True)
-
-        elif "PLAIN_MESSAGE" in description:
-            try:
-                view = PlainEditorView(self, notification_id, channel_id, hours, minutes, description, mention, repeat,
-                                       next_notification, timezone, notification_type)
-
-                next_notification_date = datetime.fromisoformat(next_notification).strftime("%d/%m/%Y")
-                formatted_repeat = format_repeat_interval(repeat, notification_id)
-                formatted_mention = format_mention(mention)
-                formatted_type = format_notification_type(notification_type)
-                embed = discord.Embed(
-                    title="Editing Notification",
-                    description=(
-                        f"**{theme.calendarIcon} Next Notification date:** {next_notification_date}\n"
-                        f"**{theme.timeIcon} Time:** {hours:02d}:{minutes:02d} ({timezone})\n"
-                        f"**{theme.announceIcon} Channel:** <#{channel_id}>\n"
-                        f"**{theme.editListIcon} Description:** {description}\n\n"
-                        f"**{theme.settingsIcon} Notification Type**\n{formatted_type}\n\n"
-                        f"**{theme.membersIcon} Mention:** {formatted_mention}\n"
-                        f"**{theme.retryIcon} Repeat:** {formatted_repeat}\n"
-                    ),
-                    color=theme.emColor1,
-                )
-                await interaction.response.defer()
-                message = await interaction.followup.send(embed=embed, view=view, ephemeral=True)
-            except Exception as e:
-                logger.error(f"Error during PLAIN_MESSAGE handling: {e}")
-                print(f"[ERROR] During PLAIN_MESSAGE handling: {e}")
-                await interaction.followup.send(f"An error occurred in PLAIN_MESSAGE section. {e}", ephemeral=True)
+            if not result:
+                await interaction.response.send_message(f"{theme.deniedIcon} Notification ID not found.", ephemeral=True)
                 return
-        else:
-            logger.warning(f"No known format matched, description is {description}")
 
-        view.message = message
+            channel_id, hours, minutes, description, mention, repeat, next_notification, timezone, notification_type, event_type = result
+            if "EMBED_MESSAGE" in description:
+                cursor.execute(
+                    "SELECT title, description, color, image_url, thumbnail_url, footer, author, mention_message FROM bear_notification_embeds WHERE notification_id = ?",
+                    (notification_id,))
+                embed_results = cursor.fetchone()
+                if not embed_results:
+                    await interaction.response.send_message(
+                        f"{theme.deniedIcon} Embed data is missing for this notification.",
+                        ephemeral=True
+                    )
+                    return
+                title, embed_description, color, image_url, thumbnail_url, footer, author, mention_message = embed_results
+
+                view = EmbedDataView(self, notification_id, title, embed_description, color, image_url, thumbnail_url,
+                                     footer, author, mention_message, event_type, hours, minutes, next_notification)
+
+                # Replace variables for initial display
+                embed = discord.Embed(
+                    title=view._replace_variables(title),
+                    description=view._replace_variables(embed_description),
+                    color=color,
+                )
+                if footer:
+                    embed.set_footer(text=view._replace_variables(footer))
+                if author:
+                    embed.set_author(name=view._replace_variables(author))
+                if image_url:
+                    embed.set_image(url=image_url)
+                if thumbnail_url:
+                    embed.set_thumbnail(url=thumbnail_url)
+
+                mention_preview = view._replace_variables(mention_message) if mention_message else ""
+
+                await interaction.response.defer()
+                if original_message:
+                    await original_message.edit(content=mention_preview, embed=embed, view=view)
+                    message = original_message
+                else:
+                    message = await interaction.followup.send(content=mention_preview, embed=embed, view=view,
+                                                              ephemeral=True)
+
+            elif "PLAIN_MESSAGE" in description:
+                try:
+                    view = PlainEditorView(self, notification_id, channel_id, hours, minutes, description, mention, repeat,
+                                           next_notification, timezone, notification_type)
+
+                    next_notification_date = datetime.fromisoformat(next_notification).strftime("%d/%m/%Y")
+                    formatted_repeat = format_repeat_interval(repeat, notification_id)
+                    formatted_mention = format_mention(mention)
+                    formatted_type = format_notification_type(notification_type)
+                    embed = discord.Embed(
+                        title="Editing Notification",
+                        description=(
+                            f"**{theme.calendarIcon} Next Notification date:** {next_notification_date}\n"
+                            f"**{theme.timeIcon} Time:** {hours:02d}:{minutes:02d} ({timezone})\n"
+                            f"**{theme.announceIcon} Channel:** <#{channel_id}>\n"
+                            f"**{theme.editListIcon} Description:** {description}\n\n"
+                            f"**{theme.settingsIcon} Notification Type**\n{formatted_type}\n\n"
+                            f"**{theme.membersIcon} Mention:** {formatted_mention}\n"
+                            f"**{theme.retryIcon} Repeat:** {formatted_repeat}\n"
+                        ),
+                        color=theme.emColor1,
+                    )
+                    await interaction.response.defer()
+                    message = await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+                except Exception as e:
+                    logger.error(f"Error during PLAIN_MESSAGE handling: {e}")
+                    print(f"[ERROR] During PLAIN_MESSAGE handling: {e}")
+                    await interaction.followup.send(f"An error occurred in PLAIN_MESSAGE section. {e}", ephemeral=True)
+                    return
+            else:
+                logger.warning(f"No known format matched, description is {description}")
+                await interaction.response.send_message(
+                    f"{theme.deniedIcon} Could not parse this notification's format.",
+                    ephemeral=True
+                )
+                return
+
+            view.message = message
+        finally:
+            conn.close()
 
     async def update_notification(self, view):
         conn = sqlite3.connect("db/beartime.sqlite")
-        cursor = conn.cursor()
+        try:
+            cursor = conn.cursor()
 
-        if view.repeat == -1:
-            cursor.execute("DELETE FROM notification_days WHERE notification_id = ?", (view.notification_id,))
+            if view.repeat == -1:
+                cursor.execute("DELETE FROM notification_days WHERE notification_id = ?", (view.notification_id,))
 
-            weekday = getattr(view, "weekdays", "")
-            cursor.execute("INSERT INTO notification_days (notification_id, weekday) VALUES (?, ?)",(view.notification_id, weekday))
-        else:
-            cursor.execute("DELETE FROM notification_days WHERE notification_id = ?", (view.notification_id,))
+                weekday = getattr(view, "weekdays", "")
+                cursor.execute("INSERT INTO notification_days (notification_id, weekday) VALUES (?, ?)",(view.notification_id, weekday))
+            else:
+                cursor.execute("DELETE FROM notification_days WHERE notification_id = ?", (view.notification_id,))
 
-        # Refresh the last-known channel name so quarantine DMs name the right channel.
-        channel_name = getattr(self.bot.get_channel(view.channel_id), "name", None)
-        cursor.execute(
-            "UPDATE bear_notifications SET channel_id = ?, channel_name = ?, hour = ?, minute = ?, description = ?, mention_type = ?, repeat_minutes = ?, next_notification = ?, notification_type = ? WHERE id = ?",
-            (view.channel_id, channel_name, view.hours, view.minutes, view.description, view.mention, view.repeat,
-             view.next_notification, view.notification_type, view.notification_id)
-        )
-        conn.commit()
+            # Refresh the last-known channel name so quarantine DMs name the right channel.
+            channel_name = getattr(self.bot.get_channel(view.channel_id), "name", None)
+            cursor.execute(
+                "UPDATE bear_notifications SET channel_id = ?, channel_name = ?, hour = ?, minute = ?, description = ?, mention_type = ?, repeat_minutes = ?, next_notification = ?, notification_type = ? WHERE id = ?",
+                (view.channel_id, channel_name, view.hours, view.minutes, view.description, view.mention, view.repeat,
+                 view.next_notification, view.notification_type, view.notification_id)
+            )
+            conn.commit()
 
-        # Get guild_id for schedule board update
-        cursor.execute("SELECT guild_id FROM bear_notifications WHERE id = ?", (view.notification_id,))
-        result = cursor.fetchone()
-        guild_id = result[0] if result else None
-
-        conn.close()
+            # Get guild_id for schedule board update
+            cursor.execute("SELECT guild_id FROM bear_notifications WHERE id = ?", (view.notification_id,))
+            result = cursor.fetchone()
+            guild_id = result[0] if result else None
+        finally:
+            conn.close()
 
         # Notify schedule boards of update
         if guild_id:
@@ -1055,20 +1072,21 @@ class NotificationEditor(commands.Cog):
 
     async def update_embed_notification(self, view):
         conn = sqlite3.connect("db/beartime.sqlite")
-        cursor = conn.cursor()
+        try:
+            cursor = conn.cursor()
 
-        cursor.execute(
-            "UPDATE bear_notification_embeds SET title = ?, description = ?, color = ?, image_url = ?, thumbnail_url = ?, footer = ?, author = ?, mention_message = ? WHERE notification_id = ?",
-            (view.title, view.embed_description, view.color, view.image_url, view.thumbnail_url, view.footer,
-             view.author, view.mention_message, view.notification_id)
-        )
-        conn.commit()
+            cursor.execute(
+                "UPDATE bear_notification_embeds SET title = ?, description = ?, color = ?, image_url = ?, thumbnail_url = ?, footer = ?, author = ?, mention_message = ? WHERE notification_id = ?",
+                (view.title, view.embed_description, view.color, view.image_url, view.thumbnail_url, view.footer,
+                 view.author, view.mention_message, view.notification_id)
+            )
+            conn.commit()
 
-        # Get guild_id and channel_id for schedule board update
-        cursor.execute("SELECT guild_id, channel_id FROM bear_notifications WHERE id = ?", (view.notification_id,))
-        result = cursor.fetchone()
-
-        conn.close()
+            # Get guild_id and channel_id for schedule board update
+            cursor.execute("SELECT guild_id, channel_id FROM bear_notifications WHERE id = ?", (view.notification_id,))
+            result = cursor.fetchone()
+        finally:
+            conn.close()
 
         if result:
             guild_id, channel_id = result

--- a/cogs/notification_schedule.py
+++ b/cogs/notification_schedule.py
@@ -635,7 +635,7 @@ class NotificationSchedule(commands.Cog):
 
                         for row in rows:
                             parts = row[0].split('|')
-                            notification_days.update(int(p) for p in parts)
+                            notification_days.update(int(p) for p in parts if p)
 
                         # Generate occurrences for each matching weekday
                         current_date = next_time.date()

--- a/cogs/notification_system.py
+++ b/cogs/notification_system.py
@@ -624,7 +624,7 @@ class NotificationSystem(commands.Cog):
 
             # If start_date is provided, use it as the base date (for wizard updates)
             if start_date:
-                next_notification = start_date.replace(hour=hour, minute=minute, second=0, microsecond=0)
+                next_notification = tz.localize(start_date.replace(hour=hour, minute=minute, second=0, microsecond=0, tzinfo=None))
             else:
                 # Fall back to existing behavior: keep current date, update time only
                 self.cursor.execute("SELECT next_notification FROM bear_notifications WHERE id = ?", (notification_id,))

--- a/main.py
+++ b/main.py
@@ -1009,15 +1009,15 @@ if __name__ == "__main__":
                                 src_path = os.path.join(root, file)
                                 rel_path = os.path.relpath(src_path, update_dir)
                                 dst_path = os.path.join(".", rel_path)
-                                
+                                norm_path = dst_path.replace("\\", "/")
+
                                 # Skip certain files that shouldn't be overwritten
-                                if file in ["bot_token.txt", "version"] or dst_path.startswith("db/") or dst_path.startswith("db\\"):
+                                if file in ["bot_token.txt", "version"] or norm_path.startswith("db/") or norm_path.startswith("./db/"):
                                     continue
-                                
+
                                 os.makedirs(os.path.dirname(dst_path), exist_ok=True)
 
                                 # Only backup cogs Python files (.py extension)
-                                norm_path = dst_path.replace("\\", "/")
                                 is_cogs_file = (norm_path.startswith("cogs/") or norm_path.startswith("./cogs/")) and file.endswith(".py")
                                 
                                 if is_cogs_file and os.path.exists(dst_path):


### PR DESCRIPTION
## Summary

This branch fixes a set of latent bugs found by a full read of the cogs: reachable crashes (AttributeError / TypeError / UnboundLocalError / OperationalError), sqlite connection leaks, and two wrong-type comparisons that silently disable a feature. Each change is surgical and matches an existing sibling pattern in the same file. No behavior changes beyond the fix.

Base branch is even with `v2.1.2`. 13 commits, one per file, so any single fix can be cherry-picked or dropped.

## Fixes

**Members / alliance**
- `alliance_member_operations.py` — `users.alliance` is `TEXT` (stores `'1'`) but `alliance_list.alliance_id` is `INTEGER`, so `int == str` was always `False`. This made the giftcode "Find by Player ID" permission check always deny, and failed to exclude a member's own alliance from transfer targets. Compare as strings. Also: `State` sort now handles a `NULL` `kid` (was `None < int` TypeError), and the member ID search guards a deleted-alliance lookup.
- `alliance.py` — `/settings` used `guild.get_member(bot_id)`, which can be `None` (member not cached) → AttributeError. Use `guild.me` and guard `None`.
- `alliance_history.py` — an empty alliance built `WHERE fid IN ()` (OperationalError on sqlite < 3.51). Short-circuit to the "no changes" reply. Also guard the alliance-name lookup when the name no longer resolves (renamed/deleted).

**Gift codes**
- `gift_redemption.py` — `_summary_names_block()` was called with an `overflow=` keyword it does not accept, so the "Member Auto-removed" audit embed silently never posted while the member was still deleted. Also keep a sticky error state so an alliance with any failing code does not finish as "completed".
- `gift_operationsapi.py` — `is_valid` was unbound when the `GiftOperations` cog is missing → UnboundLocalError. Default it to `None`.

**Minister scheduling**
- `minister_schedule.py` — `interaction.user.avatar.url` crashed for default-avatar users (avatar is `None`) after the booking was already committed. Guard it as the sibling sites do.
- `minister_menu.py` — `log_guild.get_channel(...)` ran before the `None` check (and one path had no check). Move/add the guard before use.
- `minister_archive.py` — remove a db connection that was opened but never used (and not closed on error).

**Notifications**
- `notification_system.py` — the wizard update path stamped local hour/minute onto a UTC-aware datetime instead of `tz.localize()`, shifting the notification time by the timezone offset on re-run. Match the create path.
- `notification_editor.py` — sqlite connections leaked on every editor open and on error paths; wrap in `try/finally: conn.close()`. Also guard an EMBED notification with no embed row (None unpack) and an unknown description format (UnboundLocalError).
- `notification_schedule.py` — `int(p)` on an empty weekday part raised ValueError and rendered the whole board as an error. Add the `if p` filter the sibling loops already use.

**Attendance (OCR review)**
- `attendance_ocr_review.py` — bounds-check a row delete against a stale modal index; align the single-mode low-confidence count with complete mode (`"likely"` + `"review"`).

## Verification

The project has no test suite, so `py_compile` and `ruff` only confirm syntax. Each fix is verified by inspection against a sibling call site in the same file (cited above). Three are demonstrated with a before/after script:

- **Alliance-id comparison**: `1 == '1'` → `False`; `str(1) == str('1')` → `True`.
- **Notification timezone**: a UTC-aware `start_date` with `.replace(hour=14, ...)` yields `14:00+00:00`; `tz.localize(...)` yields `14:00-04:00` — a 4-5 h drift removed.
- **Empty `IN ()`**: on sqlite 3.45.1 (the deployment target), `WHERE fid IN ()` raises `OperationalError: incomplete input`; the guard removes the version dependency.

## Not included (need a design decision, deliberately out of scope)

- Scoreboard write can fail with `NOT NULL` on `attendance_session_scoreboard.rank` when OCR misses a `#rank`; the real fix is a primary-key change (`rank` is not a per-session unique id), which needs a schema migration and a maintainer decision.
- Registration/result date-match windows differ (`<= 3` vs `<= 2` days) and can orphan a session — a data-flow change, not mechanical.
- Geometric box-align merge is unreachable for Points events (a multi-file OCR plumbing change; the quality gain can't be verified without sample screenshots).
- Urgency-refresh detection window is narrower than the poll interval — widening it risks duplicate notifications; needs care.
