### PR TITLE
feature: grant admin tiers to Discord roles

### DIFF
--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -2139,16 +2139,8 @@ class AllianceMemberOperations(commands.Cog):
             logger.warning(f"member_add: could not DM invoker {invoker_id} with headless result ({e})")
 
     async def is_admin(self, user_id):
-        try:
-            with sqlite3.connect('db/settings.sqlite') as conn:
-                cursor = conn.cursor()
-                cursor.execute("SELECT id FROM admin WHERE id = ?", (user_id,))
-                result = cursor.fetchone()
-                is_admin = result is not None
-                return is_admin
-        except Exception as e:
-            logger.error(f"Error in admin check: {e}")
-            return False
+        is_admin, _ = PermissionManager.is_admin(user_id)
+        return is_admin
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/attendance_ocr.py
+++ b/cogs/attendance_ocr.py
@@ -203,7 +203,8 @@ class AttendanceOCR(commands.Cog):
         # Per-alliance permission gate. When restricted, only bot admins
         # can post screenshots for processing; others get a self-deleting notice.
         if get_ocr_upload_admin_only(settings["alliance_id"]):
-            is_admin, _ = PermissionManager.is_admin(message.author.id)
+            role_ids = [r.id for r in getattr(message.author, "roles", [])]
+            is_admin, _ = PermissionManager.is_member_admin(message.author.id, role_ids)
             if not is_admin:
                 await message.channel.send(
                     f"{theme.deniedIcon} Only admins can upload screenshots here.",

--- a/cogs/bot_main_menu.py
+++ b/cogs/bot_main_menu.py
@@ -1289,9 +1289,10 @@ class AdminManagerView(discord.ui.View):
             title=f"{theme.lockIcon} Permissions",
             description=(
                 f"Permissions system allows you to configure access levels for admins. "
-                f"Higher tiers can do everything lower tiers can. Use the dropdowns "
-                f"below to add a new admin or open an existing one to change their tier, "
-                f"scope, or remove them.\n\n"
+                f"Higher tiers can do everything lower tiers can, and when someone holds "
+                f"more than one grant (their own or via roles) the broadest one wins, with "
+                f"alliance scopes combined. Use the dropdowns below to add a new admin or "
+                f"open an existing one to change their tier, scope, or remove them.\n\n"
                 f"**Tiers**\n"
                 f"{theme.upperDivider}\n"
                 f"{theme.crownIcon} **Bot Owner** — recovery anchor; only one; "
@@ -1302,6 +1303,8 @@ class AdminManagerView(discord.ui.View):
                 f"on their Discord server\n"
                 f"{theme.pinIcon} **Alliance Admin** — limited to the specific "
                 f"alliance(s) they're assigned to\n"
+                f"{theme.membersIcon} **Roles** — any tier can also be granted to a "
+                f"Discord role; every holder inherits it (**Manage Roles** below)\n"
                 f"{theme.lowerDivider}\n\n"
                 f"**Current state**\n"
                 f"{theme.upperDivider}\n"
@@ -1418,6 +1421,13 @@ class AdminManagerView(discord.ui.View):
         audit_btn.callback = self._on_view_audit
         self.add_item(audit_btn)
 
+        roles_btn = discord.ui.Button(
+            label="Manage Roles", style=discord.ButtonStyle.secondary,
+            emoji=theme.membersIcon, row=4,
+        )
+        roles_btn.callback = self._on_manage_roles
+        self.add_item(roles_btn)
+
         back_btn = discord.ui.Button(
             label="Back", style=discord.ButtonStyle.secondary,
             emoji=theme.backIcon, row=4,
@@ -1426,6 +1436,13 @@ class AdminManagerView(discord.ui.View):
         self.add_item(back_btn)
 
     # ───── callbacks ─────
+
+    async def _on_manage_roles(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        view = RoleManagerView(self.cog, self.viewer_id, parent_view=self)
+        await view.refresh_data(self.cog.bot)
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
 
     async def _on_view_audit(self, interaction):
         if not await check_interaction_user(interaction, self.viewer_id):
@@ -1636,6 +1653,14 @@ async def _resolve_user_name(bot, user_id: int) -> str:
         except Exception:
             user = None
     return user.display_name if user else f"User {user_id}"
+
+
+async def _resolve_role_name(bot, guild_id: int, role_id: int) -> str:
+    """Role name if the guild + role are still cached, else a raw-id fallback
+    (the grant is still removable even when the role no longer exists)."""
+    guild = bot.get_guild(guild_id) if guild_id else None
+    role = guild.get_role(role_id) if guild else None
+    return role.name if role else f"Role {role_id}"
 
 
 async def _return_to_parent(interaction, parent_view, bot):
@@ -2141,6 +2166,488 @@ class TransferOwnerView(discord.ui.View):
         PermissionManager.log_change(
             self.viewer_id, "transfer_owner", target_id,
             before_target, PermissionManager.describe_state(target_id),
+        )
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+    async def _refresh_self(self, interaction):
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_back(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+
+# ============================================================================
+# Role Grant Views (an admin tier granted to a Discord role instead of a user)
+# ============================================================================
+
+class RoleManagerView(discord.ui.View):
+    """Paginated list of role-based admin grants. Selecting a role opens
+    RoleContextView. Mirrors AdminManagerView, scoped to roles."""
+
+    PAGE_SIZE = 25
+
+    def __init__(self, cog, viewer_id: int, parent_view: AdminManagerView):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.viewer_id = viewer_id
+        self.parent_view = parent_view
+        self.page = 0
+        # Populated by refresh_data():
+        self.grants: list = []
+        self._names: dict = {}
+        self.add_select: discord.ui.RoleSelect = None
+
+    async def refresh_data(self, bot):
+        self.grants = PermissionManager.list_role_grants()
+        names = await asyncio.gather(
+            *(_resolve_role_name(bot, g['guild_id'], g['role_id']) for g in self.grants)
+        )
+        self._names = {g['role_id']: n for g, n in zip(self.grants, names)}
+        self._build()
+
+    def _total_pages(self) -> int:
+        return max(1, -(-len(self.grants) // self.PAGE_SIZE))
+
+    def build_embed(self) -> discord.Embed:
+        counts = {TIER_GLOBAL: 0, TIER_SERVER: 0, TIER_ALLIANCE: 0}
+        for g in self.grants:
+            counts[g['tier']] = counts.get(g['tier'], 0) + 1
+
+        embed = discord.Embed(
+            title=f"{theme.membersIcon} Role Grants",
+            description=(
+                f"Grant an admin tier to a Discord role so every member holding "
+                f"it inherits the permission. Pick a role below to add a grant, "
+                f"or open an existing one to change its tier, scope, or remove it.\n\n"
+                f"{theme.upperDivider}\n"
+                f"**Total role grants:** {len(self.grants)} "
+                f"· {counts[TIER_GLOBAL]} Global · {counts[TIER_SERVER]} Server · "
+                f"{counts[TIER_ALLIANCE]} Alliance\n"
+                f"{theme.lowerDivider}"
+            ),
+            color=theme.emColor1,
+        )
+        if self.grants:
+            total_pages = self._total_pages()
+            start = self.page * self.PAGE_SIZE
+            end = min(start + self.PAGE_SIZE, len(self.grants))
+            lines = []
+            for g in self.grants[start:end]:
+                name = self._names.get(g['role_id']) or f"Role {g['role_id']}"
+                icon = _tier_icon(g['tier'])
+                tier_text = _tier_label(g['tier'])
+                if g['tier'] == TIER_ALLIANCE:
+                    tier_text += f" ({g['alliance_count']})"
+                lines.append(f"{icon} **{name}** (<@&{g['role_id']}>) — {tier_text}")
+            header = (
+                f"Role Grants {start + 1}–{end} of {len(self.grants)}"
+                if total_pages > 1 else f"Role Grants ({len(self.grants)})"
+            )
+            embed.add_field(name=header, value="\n".join(lines)[:1024], inline=False)
+        else:
+            embed.add_field(
+                name="Role Grants (0)",
+                value="*No role grants yet. Use the role picker below to add the first one.*",
+                inline=False,
+            )
+        return embed
+
+    def _build(self):
+        self.clear_items()
+
+        # Row 0: Add a grant via RoleSelect (single role).
+        self.add_select = discord.ui.RoleSelect(
+            placeholder="+ Add role grant (pick a role)…",
+            min_values=1, max_values=1, row=0,
+        )
+        self.add_select.callback = self._on_add_role_picked
+        self.add_item(self.add_select)
+
+        # Row 1: open-grant Select for the current page.
+        if self.grants:
+            start = self.page * self.PAGE_SIZE
+            end = min(start + self.PAGE_SIZE, len(self.grants))
+            options = []
+            for g in self.grants[start:end]:
+                name = self._names.get(g['role_id']) or f"Role {g['role_id']}"
+                tier = g['tier']
+                desc = {
+                    TIER_GLOBAL: "Global — full access",
+                    TIER_SERVER: "Server — all alliances on the server",
+                    TIER_ALLIANCE: f"Alliance — {g['alliance_count']} alliance(s)",
+                }.get(tier, tier)
+                options.append(discord.SelectOption(
+                    label=f"{name}"[:100],
+                    value=str(g['role_id']),
+                    description=desc[:100],
+                    emoji=_tier_icon(tier),
+                ))
+            role_select = discord.ui.Select(
+                placeholder="Open a role grant…",
+                options=options, min_values=1, max_values=1, row=1,
+            )
+            role_select.callback = self._on_role_picked
+            self.add_item(role_select)
+
+        # Row 2: pagination (only when needed).
+        total_pages = self._total_pages()
+        if total_pages > 1:
+            prev_btn = discord.ui.Button(
+                label="◀ Prev", style=discord.ButtonStyle.secondary,
+                row=2, disabled=(self.page == 0),
+            )
+            prev_btn.callback = self._on_prev
+            page_lbl = discord.ui.Button(
+                label=f"Page {self.page + 1}/{total_pages}",
+                style=discord.ButtonStyle.secondary,
+                row=2, disabled=True,
+            )
+            next_btn = discord.ui.Button(
+                label="Next ▶", style=discord.ButtonStyle.secondary,
+                row=2, disabled=(self.page >= total_pages - 1),
+            )
+            next_btn.callback = self._on_next
+            self.add_item(prev_btn)
+            self.add_item(page_lbl)
+            self.add_item(next_btn)
+
+        # Row 3: Back (to the user-admin list).
+        back_btn = discord.ui.Button(
+            label="Back", style=discord.ButtonStyle.secondary,
+            emoji=theme.backIcon, row=3,
+        )
+        back_btn.callback = self._on_back
+        self.add_item(back_btn)
+
+    # ───── callbacks ─────
+
+    async def _on_add_role_picked(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        if not self.add_select.values:
+            await interaction.response.defer()
+            return
+        role = self.add_select.values[0]
+        if any(g['role_id'] == role.id for g in self.grants):
+            await interaction.response.send_message(
+                f"{theme.warnIcon} {role.mention} already has a grant. Pick it from the list to edit.",
+                ephemeral=True,
+            )
+            return
+        view = AddRoleView(self.cog, self.viewer_id, role, parent_view=self)
+        await view.refresh_data()
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+    async def _on_role_picked(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        role_id = int(interaction.data['values'][0])
+        grant = next((g for g in self.grants if g['role_id'] == role_id), None)
+        guild_id = grant['guild_id'] if grant else interaction.guild_id
+        view = RoleContextView(self.cog, self.viewer_id, role_id, guild_id, parent_view=self)
+        await view.refresh_data(self.cog.bot)
+        await interaction.response.edit_message(embed=view.build_embed(), view=view)
+
+    async def _on_prev(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        if self.page > 0:
+            self.page -= 1
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_next(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        if self.page < self._total_pages() - 1:
+            self.page += 1
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_back(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+
+class AddRoleView(discord.ui.View):
+    """Pick tier + (conditional) alliances for a freshly-selected role, then
+    Confirm to insert the grant in one shot. Mirrors AddAdminView for roles."""
+
+    MAX_ALLIANCE_OPTIONS = 25
+
+    def __init__(self, cog, viewer_id: int, role: discord.Role, parent_view: RoleManagerView):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.viewer_id = viewer_id
+        self.role = role
+        self.parent_view = parent_view
+        self.all_alliances: list = []
+        self.staged_tier = TIER_SERVER  # safest default — server-wide, no specific assignments
+        self.staged_alliance_ids: list = []
+
+    async def refresh_data(self):
+        self.all_alliances = PermissionManager.list_alliances()
+        self._build()
+
+    def build_embed(self) -> discord.Embed:
+        return discord.Embed(
+            title=f"{theme.addIcon} Add Role Grant: {self.role.name}",
+            description=(
+                f"{theme.upperDivider}\n"
+                f"**Role:** {self.role.mention} (`{self.role.id}`)\n"
+                f"**Tier:** {_tier_label(self.staged_tier)} {_tier_icon(self.staged_tier)}\n"
+                f"{theme.lowerDivider}\n"
+                f"{_tier_blurb(self.staged_tier, alliance_count=len(self.staged_alliance_ids))}\n\n"
+                f"_Every member holding this role inherits the tier below._"
+            ),
+            color=theme.emColor1,
+        )
+
+    def _build(self):
+        self.clear_items()
+        tier_select = _build_tier_select(self.staged_tier)
+        tier_select.callback = self._on_tier_change
+        self.add_item(tier_select)
+
+        if self.staged_tier == TIER_ALLIANCE and self.all_alliances:
+            alliance_select = _build_alliance_select(
+                self.all_alliances, self.staged_alliance_ids,
+                max_options=self.MAX_ALLIANCE_OPTIONS,
+                placeholder="Pick alliances (one or more)…",
+            )
+            alliance_select.callback = self._on_alliances_change
+            self.add_item(alliance_select)
+
+        confirm_btn = discord.ui.Button(
+            label="Add Role Grant", emoji=theme.verifiedIcon,
+            style=discord.ButtonStyle.success, row=2,
+        )
+        confirm_btn.callback = self._on_confirm
+        self.add_item(confirm_btn)
+
+        cancel_btn = discord.ui.Button(
+            label="Cancel", emoji=theme.backIcon,
+            style=discord.ButtonStyle.secondary, row=2,
+        )
+        cancel_btn.callback = self._on_cancel
+        self.add_item(cancel_btn)
+
+    async def _on_tier_change(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        self.staged_tier = interaction.data['values'][0]
+        if self.staged_tier != TIER_ALLIANCE:
+            self.staged_alliance_ids = []
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_alliances_change(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        self.staged_alliance_ids = [int(v) for v in (interaction.data.get('values') or [])]
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_confirm(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        if self.staged_tier == TIER_ALLIANCE and not self.staged_alliance_ids:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} Pick at least one alliance, or switch tier to Server (manages all).",
+                ephemeral=True,
+            )
+            return
+        try:
+            PermissionManager.add_role_grant(
+                self.role.id, self.role.guild.id, tier=self.staged_tier,
+                alliance_ids=self.staged_alliance_ids if self.staged_tier == TIER_ALLIANCE else None,
+            )
+        except ValueError as e:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} {e}", ephemeral=True,
+            )
+            return
+        PermissionManager.log_change(
+            self.viewer_id, "role_add", self.role.id,
+            "Not a granted role", PermissionManager.describe_role_state(self.role.id),
+        )
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+    async def _on_cancel(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+
+class RoleContextView(discord.ui.View):
+    """Per-role-grant actions: change tier, assign/unassign alliances, remove
+    the grant. Mirrors AdminContextView for roles (no Owner tier, no transfer)."""
+
+    MAX_ALLIANCE_OPTIONS = 25
+
+    def __init__(self, cog, viewer_id: int, role_id: int, guild_id: int, parent_view: RoleManagerView):
+        super().__init__(timeout=7200)
+        self.cog = cog
+        self.viewer_id = viewer_id
+        self.role_id = role_id
+        self.guild_id = guild_id
+        self.parent_view = parent_view
+        # Populated by refresh_data():
+        self.role_name = None
+        self.target_tier = TIER_NONE
+        self.target_alliance_ids: list = []
+        self.all_alliances: list = []
+        self.staged_tier = TIER_GLOBAL          # what the grant will be saved as
+        self.staged_alliance_ids: list = []     # diffed against current on Save
+
+    async def refresh_data(self, bot):
+        self.role_name = await _resolve_role_name(bot, self.guild_id, self.role_id)
+        self.target_tier = PermissionManager.get_role_tier(self.role_id)
+        self.all_alliances = PermissionManager.list_alliances()
+        self.target_alliance_ids = PermissionManager.get_role_alliance_assignments(self.role_id)
+        self.staged_tier = self.target_tier
+        self.staged_alliance_ids = list(self.target_alliance_ids)
+        self._build()
+
+    def build_embed(self) -> discord.Embed:
+        tier = self.target_tier
+        icon = _tier_icon(tier)
+        embed = discord.Embed(
+            title=f"{icon} {self.role_name}",
+            description=(
+                f"{theme.upperDivider}\n"
+                f"**Tier:** {_tier_label(tier)}\n"
+                f"**Role:** <@&{self.role_id}> (`{self.role_id}`)\n"
+                f"{theme.lowerDivider}"
+            ),
+            color=theme.emColor1,
+        )
+        embed.add_field(
+            name="Scope",
+            value=_tier_blurb(tier, alliance_count=len(self.target_alliance_ids)),
+            inline=False,
+        )
+        if tier == TIER_ALLIANCE and self.target_alliance_ids:
+            id_to_name = {aid: name for aid, name in self.all_alliances}
+            assigned = [
+                f"`{id_to_name.get(aid, f'#{aid}')}`"
+                for aid in self.target_alliance_ids
+            ]
+            embed.add_field(
+                name=f"Assigned Alliances ({len(assigned)})",
+                value=", ".join(assigned)[:1024],
+                inline=False,
+            )
+        return embed
+
+    def _build(self):
+        self.clear_items()
+        tier_select = _build_tier_select(self.staged_tier)
+        tier_select.callback = self._on_tier_change
+        self.add_item(tier_select)
+
+        if self.staged_tier == TIER_ALLIANCE and self.all_alliances:
+            alliance_select = _build_alliance_select(
+                self.all_alliances, self.staged_alliance_ids,
+                max_options=self.MAX_ALLIANCE_OPTIONS,
+            )
+            alliance_select.callback = self._on_alliances_change
+            self.add_item(alliance_select)
+
+        # Row 2: Save / Remove / Back
+        save_btn = discord.ui.Button(
+            label="Save", emoji=theme.saveIcon,
+            style=discord.ButtonStyle.success, row=2,
+        )
+        save_btn.callback = self._on_save
+        self.add_item(save_btn)
+
+        remove_btn = discord.ui.Button(
+            label="Remove Grant", emoji=theme.trashIcon,
+            style=discord.ButtonStyle.danger, row=2,
+        )
+        remove_btn.callback = self._on_remove
+        self.add_item(remove_btn)
+
+        back_btn = discord.ui.Button(
+            label="Back", emoji=theme.backIcon,
+            style=discord.ButtonStyle.secondary, row=2,
+        )
+        back_btn.callback = self._on_back
+        self.add_item(back_btn)
+
+    # ───── callbacks ─────
+
+    async def _on_tier_change(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        self.staged_tier = interaction.data['values'][0]
+        if self.staged_tier != TIER_ALLIANCE:
+            self.staged_alliance_ids = []
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_alliances_change(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        self.staged_alliance_ids = [int(v) for v in (interaction.data.get('values') or [])]
+        self._build()
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_save(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        if self.staged_tier == TIER_ALLIANCE and not self.staged_alliance_ids:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} Alliance tier needs at least one alliance picked. "
+                f"Pick alliances or change tier to Server (manages all alliances).",
+                ephemeral=True,
+            )
+            return
+        before_state = PermissionManager.describe_role_state(self.role_id)
+        try:
+            PermissionManager.set_role_tier(
+                self.role_id, self.staged_tier,
+                alliance_ids=self.staged_alliance_ids if self.staged_tier == TIER_ALLIANCE else None,
+            )
+        except ValueError as e:
+            await interaction.response.send_message(
+                f"{theme.deniedIcon} {e}", ephemeral=True,
+            )
+            return
+        PermissionManager.log_change(
+            self.viewer_id, "role_set_tier", self.role_id,
+            before_state, PermissionManager.describe_role_state(self.role_id),
+        )
+        await _return_to_parent(interaction, self.parent_view, self.cog.bot)
+
+    async def _on_remove(self, interaction):
+        if not await check_interaction_user(interaction, self.viewer_id):
+            return
+        confirm_view = _ConfirmActionView(
+            self.viewer_id,
+            on_confirm=lambda i: self._do_remove(i),
+            on_cancel=lambda i: self._refresh_self(i),
+        )
+        embed = discord.Embed(
+            title=f"{theme.warnIcon} Confirm Remove",
+            description=(
+                f"Remove the grant on **{self.role_name}** — currently "
+                f"**{_tier_label(self.target_tier)}**?\nThis cannot be undone."
+            ),
+            color=theme.emColor2,
+        )
+        await interaction.response.edit_message(embed=embed, view=confirm_view)
+
+    async def _do_remove(self, interaction):
+        before_state = PermissionManager.describe_role_state(self.role_id)
+        PermissionManager.remove_role_grant(self.role_id)
+        PermissionManager.log_change(
+            self.viewer_id, "role_remove", self.role_id,
+            before_state, "removed",
         )
         await _return_to_parent(interaction, self.parent_view, self.cog.bot)
 

--- a/cogs/bot_operations.py
+++ b/cogs/bot_operations.py
@@ -239,6 +239,12 @@ class BotOperations(commands.Cog):
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):
+        # Cache the member's role-derived admin grant before any permission check runs.
+        member = interaction.user
+        role_ids = [r.id for r in getattr(member, "roles", [])]
+        if role_ids:
+            PermissionManager.cache_member_role_grant(member.id, role_ids, interaction.guild_id)
+
         if not interaction.type == discord.InteractionType.component:
             return
 

--- a/cogs/minister_menu.py
+++ b/cogs/minister_menu.py
@@ -836,21 +836,15 @@ class MinisterMenu(commands.Cog):
             pass
 
     async def is_admin(self, user_id: int) -> bool:
-        with closing(sqlite3.connect('db/settings.sqlite')) as settings_conn:
-            settings_cursor = settings_conn.cursor()
-
-            if user_id == self.bot.owner_id:
-                return True
-
-            settings_cursor.execute("SELECT 1 FROM admin WHERE id=?", (user_id,))
-            return settings_cursor.fetchone() is not None
+        is_admin, _ = PermissionManager.is_admin(user_id)
+        return is_admin
 
     async def show_minister_channel_menu(self, interaction: discord.Interaction):
         # Store the original interaction for later updates
 
         # Get channel status and permissions
         channel_status, embed_color = await self.get_channel_status_display()
-        _, is_global, _ = await self.get_admin_permissions(interaction.user.id)
+        _, is_global, _ = await self.get_admin_permissions(interaction.user.id, interaction.guild.id if interaction.guild else None)
 
         embed = discord.Embed(
             title="🏛️ Minister Scheduling",
@@ -963,24 +957,20 @@ class MinisterMenu(commands.Cog):
         status_text = "\n".join(status_lines)
         return status_text, embed_color
 
-    async def get_admin_permissions(self, user_id: int):
-        """Get admin permissions - delegates to centralized PermissionManager"""
+    async def get_admin_permissions(self, user_id: int, guild_id: int | None = None):
+        """Get admin permissions - delegates to centralized PermissionManager (role-aware)."""
         is_admin, is_global = PermissionManager.is_admin(user_id)
         if not is_admin:
             return False, False, []
         if is_global:
             return True, True, []
-        # Get alliance-specific permissions for server admin
-        with sqlite3.connect('db/settings.sqlite') as db:
-            cursor = db.cursor()
-            cursor.execute("SELECT alliances_id FROM adminserver WHERE admin=?", (user_id,))
-            alliance_ids = [row[0] for row in cursor.fetchall()]
+        alliance_ids, _ = PermissionManager.get_admin_alliance_ids(user_id, guild_id)
         return True, False, alliance_ids
 
     async def show_filtered_user_select(self, interaction: discord.Interaction, activity_name: str):
         """Show the filtered user selection view"""
         # Check admin permissions
-        is_admin, is_global_admin, alliance_ids = await self.get_admin_permissions(interaction.user.id)
+        is_admin, is_global_admin, alliance_ids = await self.get_admin_permissions(interaction.user.id, interaction.guild.id if interaction.guild else None)
 
         if not is_admin:
             await interaction.response.send_message(f"{theme.deniedIcon} You do not have permission to manage minister appointments.", ephemeral=True)
@@ -1118,7 +1108,7 @@ class MinisterMenu(commands.Cog):
     async def show_clear_confirmation(self, interaction: discord.Interaction, activity_name: str):
         """Show confirmation for clearing appointments"""
         # Check permissions
-        is_admin, is_global_admin, alliance_ids = await self.get_admin_permissions(interaction.user.id)
+        is_admin, is_global_admin, alliance_ids = await self.get_admin_permissions(interaction.user.id, interaction.guild.id if interaction.guild else None)
         
         if is_global_admin:
             # Count all appointments
@@ -1547,7 +1537,7 @@ class MinisterMenu(commands.Cog):
     
     async def show_settings_menu(self, interaction: discord.Interaction):
         """Show the minister settings menu"""
-        _, is_global, _ = await self.get_admin_permissions(interaction.user.id)
+        _, is_global, _ = await self.get_admin_permissions(interaction.user.id, interaction.guild.id if interaction.guild else None)
         embed = discord.Embed(
             title=f"{theme.settingsIcon} Minister Settings",
             description=(

--- a/cogs/minister_schedule.py
+++ b/cogs/minister_schedule.py
@@ -10,6 +10,7 @@ import logging
 import re
 from datetime import datetime
 from .pimp_my_bot import theme
+from .permission_handler import PermissionManager
 
 logger = logging.getLogger('bot')
 
@@ -227,10 +228,8 @@ class MinisterSchedule(commands.Cog):
             print(f"Error: Could not find the log channel please change it to a valid channel")
 
     async def is_admin(self, user_id: int) -> bool:
-        if user_id == self.bot.owner_id:
-            return True
-        self.settings_cursor.execute("SELECT 1 FROM admin WHERE id=?", (user_id,))
-        return self.settings_cursor.fetchone() is not None
+        is_admin, _ = PermissionManager.is_admin(user_id)
+        return is_admin
 
     async def log_change(self, action_type: str, user, appointment_type: str = None, fid: int = None,
                         nickname: str = None, old_time: str = None, new_time: str = None,

--- a/cogs/permission_handler.py
+++ b/cogs/permission_handler.py
@@ -14,6 +14,7 @@ Bot Owner anchor:
 import sqlite3
 import time
 import logging
+from contextlib import closing
 from datetime import datetime, timezone
 from typing import Tuple, List, Optional
 
@@ -54,20 +55,24 @@ class PermissionManager:
     @staticmethod
     def is_admin(user_id: int) -> Tuple[bool, bool]:
         """
-        Check if user is admin and their level.
+        Check if user is admin and their level, merging any cached role grant.
+        Guild-blind by design; alliance scope is enforced (guild-aware) in get_admin_alliance_ids.
 
         Returns:
             (is_admin, is_global) - is_global True means access to all alliances
         """
         admin_map = PermissionManager._admin_map()
-        if user_id not in admin_map:
-            return False, False
-        return True, admin_map[user_id] == 1
+        user_admin = user_id in admin_map
+        user_global = user_admin and admin_map[user_id] == 1
+        rg = PermissionManager._cached_role_grant(user_id)
+        is_admin = user_admin or bool(rg and rg["is_admin"])
+        is_global = user_global or bool(rg and rg["is_global"])
+        return is_admin, is_global
 
     @staticmethod
     def get_admin_alliance_ids(user_id: int, guild_id: int) -> Tuple[List[int], bool]:
         """
-        Get alliance IDs the admin can access.
+        Get alliance IDs the admin can access, merging any cached role grant.
 
         Returns:
             (alliance_ids, is_global)
@@ -75,83 +80,49 @@ class PermissionManager:
             - If server admin: (list of IDs, False)
         """
         is_admin, is_global = PermissionManager.is_admin(user_id)
-
         if not is_admin:
             return [], False
-
         if is_global:
             return [], True
 
-        # Server admin - check for specific assignments
-        with sqlite3.connect(PermissionManager.SETTINGS_DB) as db:
-            cursor = db.cursor()
-            cursor.execute("SELECT alliances_id FROM adminserver WHERE admin = ?", (user_id,))
-            assigned = [row[0] for row in cursor.fetchall()]
-
-        if assigned:
-            # Alliance Admin: Has specific assignments - use ONLY those
-            return assigned, False
-        else:
-            # Server Admin: No assignments - use all alliances on their Discord server
-            with sqlite3.connect(PermissionManager.ALLIANCE_DB) as alliance_db:
-                ac = alliance_db.cursor()
-                ac.execute("SELECT alliance_id FROM alliance_list WHERE discord_server_id = ?", (guild_id,))
-                return [row[0] for row in ac.fetchall()], False
+        rg = PermissionManager._cached_role_grant(user_id) or {"server": False, "alliance_ids": [], "guild_id": None}
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db:
+            user_assigned = [r[0] for r in db.execute(
+                "SELECT alliances_id FROM adminserver WHERE admin = ?", (user_id,)).fetchall()]
+        user_is_server_tier = (user_id in PermissionManager._admin_map()) and not user_assigned
+        # Role server-tier is guild-scoped: only when the cached grant came from this guild.
+        role_server = rg["server"] and rg.get("guild_id") == guild_id
+        if role_server or user_is_server_tier:
+            with closing(sqlite3.connect(PermissionManager.ALLIANCE_DB)) as adb:
+                return [r[0] for r in adb.execute(
+                    "SELECT alliance_id FROM alliance_list WHERE discord_server_id = ?", (guild_id,)).fetchall()], False
+        return sorted(set(user_assigned) | set(rg["alliance_ids"])), False
 
     @staticmethod
     def get_admin_alliances(user_id: int, guild_id: int) -> Tuple[List[Tuple], bool]:
         """
-        Get alliance tuples (id, name) for admin.
+        Get alliance tuples (id, name) for admin, merging any cached role grant.
         Used by most cogs for alliance selection dropdowns.
 
         Returns:
             (alliances, is_global)
         """
         is_admin, is_global = PermissionManager.is_admin(user_id)
-
         if not is_admin:
             return [], False
 
         if is_global:
-            # Global admin - return all alliances
-            with sqlite3.connect(PermissionManager.ALLIANCE_DB) as db:
-                cursor = db.cursor()
-                cursor.execute("""
-                    SELECT DISTINCT alliance_id, name
-                    FROM alliance_list
-                    ORDER BY name
-                """)
-                return cursor.fetchall(), True
+            with closing(sqlite3.connect(PermissionManager.ALLIANCE_DB)) as db:
+                return db.execute("SELECT DISTINCT alliance_id, name FROM alliance_list ORDER BY name").fetchall(), True
 
-        # Server admin - get their allowed alliances
-        with sqlite3.connect(PermissionManager.SETTINGS_DB) as db:
-            cursor = db.cursor()
-            cursor.execute("SELECT alliances_id FROM adminserver WHERE admin = ?", (user_id,))
-            assigned_ids = [row[0] for row in cursor.fetchall()]
-
-        if assigned_ids:
-            # Alliance Admin: Has specific assignments - use ONLY those
-            with sqlite3.connect(PermissionManager.ALLIANCE_DB) as db:
-                cursor = db.cursor()
-                placeholders = ','.join('?' * len(assigned_ids))
-                cursor.execute(f"""
-                    SELECT DISTINCT alliance_id, name
-                    FROM alliance_list
-                    WHERE alliance_id IN ({placeholders})
-                    ORDER BY name
-                """, assigned_ids)
-                return cursor.fetchall(), False
-        else:
-            # Server Admin: No assignments - use all alliances on their Discord server
-            with sqlite3.connect(PermissionManager.ALLIANCE_DB) as db:
-                cursor = db.cursor()
-                cursor.execute("""
-                    SELECT DISTINCT alliance_id, name
-                    FROM alliance_list
-                    WHERE discord_server_id = ?
-                    ORDER BY name
-                """, (guild_id,))
-                return cursor.fetchall(), False
+        ids, _ = PermissionManager.get_admin_alliance_ids(user_id, guild_id)
+        if not ids:
+            return [], False
+        with closing(sqlite3.connect(PermissionManager.ALLIANCE_DB)) as db:
+            ph = ','.join('?' * len(ids))
+            return db.execute(
+                f"SELECT DISTINCT alliance_id, name FROM alliance_list WHERE alliance_id IN ({ph}) ORDER BY name", ids
+            ).fetchall(), False
 
     @staticmethod
     def get_admin_users(user_id: int, guild_id: int = None) -> List[Tuple]:
@@ -469,3 +440,155 @@ class PermissionManager:
                 for r in cur.fetchall()
             ]
         return rows, total
+
+    # ---------------------------------------------------------------
+    # Role-grant CRUD (a Discord role holding a tier, mirroring admin/adminserver)
+    # ---------------------------------------------------------------
+
+    @staticmethod
+    def add_role_grant(role_id: int, guild_id: int, *, tier: str, alliance_ids: Optional[List[int]] = None) -> None:
+        if tier not in (TIER_GLOBAL, TIER_SERVER, TIER_ALLIANCE):
+            raise ValueError(f"Roles cannot be granted tier: {tier}")
+        if tier == TIER_ALLIANCE and not alliance_ids:
+            raise ValueError("Alliance tier requires at least one alliance_id")
+        is_initial = 1 if tier == TIER_GLOBAL else 0
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db, db:
+            db.execute("INSERT OR REPLACE INTO admin_role (role_id, guild_id, is_initial) VALUES (?, ?, ?)",
+                       (role_id, guild_id, is_initial))
+            db.execute("DELETE FROM adminserver_role WHERE role_id = ?", (role_id,))
+            if tier == TIER_ALLIANCE:
+                for aid in alliance_ids or []:
+                    db.execute("INSERT OR IGNORE INTO adminserver_role (role_id, alliances_id) VALUES (?, ?)", (role_id, aid))
+        PermissionManager._bust_role_cache()
+
+    @staticmethod
+    def set_role_tier(role_id: int, tier: str, *, alliance_ids: Optional[List[int]] = None) -> None:
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db:
+            row = db.execute("SELECT guild_id FROM admin_role WHERE role_id = ?", (role_id,)).fetchone()
+        if not row:
+            raise ValueError(f"Role {role_id} is not granted")
+        PermissionManager.add_role_grant(role_id, row[0], tier=tier, alliance_ids=alliance_ids)
+
+    @staticmethod
+    def remove_role_grant(role_id: int) -> None:
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db, db:
+            db.execute("DELETE FROM adminserver_role WHERE role_id = ?", (role_id,))
+            db.execute("DELETE FROM admin_role WHERE role_id = ?", (role_id,))
+        PermissionManager._bust_role_cache()
+
+    @staticmethod
+    def get_role_alliance_assignments(role_id: int) -> List[int]:
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db:
+            return [int(r[0]) for r in db.execute(
+                "SELECT alliances_id FROM adminserver_role WHERE role_id = ?", (role_id,)).fetchall()]
+
+    @staticmethod
+    def get_role_tier(role_id: int) -> str:
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db:
+            row = db.execute("SELECT is_initial FROM admin_role WHERE role_id = ?", (role_id,)).fetchone()
+            if not row:
+                return TIER_NONE
+            if row[0]:
+                return TIER_GLOBAL
+            n = db.execute("SELECT COUNT(*) FROM adminserver_role WHERE role_id = ?", (role_id,)).fetchone()[0]
+        return TIER_ALLIANCE if n else TIER_SERVER
+
+    @staticmethod
+    def list_role_grants() -> List[dict]:
+        with closing(sqlite3.connect(PermissionManager.SETTINGS_DB)) as db:
+            rows = db.execute(
+                "SELECT r.role_id, r.guild_id, r.is_initial, "
+                "(SELECT COUNT(*) FROM adminserver_role s WHERE s.role_id = r.role_id) "
+                "FROM admin_role r ORDER BY r.is_initial DESC, r.role_id").fetchall()
+        out = []
+        for role_id, guild_id, is_initial, count in rows:
+            tier = TIER_GLOBAL if is_initial else (TIER_ALLIANCE if count else TIER_SERVER)
+            out.append({'role_id': int(role_id), 'guild_id': guild_id, 'tier': tier, 'alliance_count': int(count)})
+        return out
+
+    @staticmethod
+    def describe_role_state(role_id: int) -> str:
+        tier = PermissionManager.get_role_tier(role_id)
+        if tier == TIER_GLOBAL:
+            return "Global Admin (role)"
+        if tier == TIER_ALLIANCE:
+            n = len(PermissionManager.get_role_alliance_assignments(role_id))
+            return f"Alliance Admin (role, {n} alliance{'s' if n != 1 else ''})"
+        if tier == TIER_SERVER:
+            return "Server Admin (role)"
+        return "Not a granted role"
+
+    # 5s TTL cache of the role-grant tables ({role_id: (tier, [alliance_ids])}).
+    _role_map_cache = None
+    _role_map_cache_at = 0.0
+    _ROLE_MAP_TTL = 5.0
+
+    @classmethod
+    def _role_admin_map(cls) -> dict:
+        now = time.monotonic()
+        if cls._role_map_cache is None or (now - cls._role_map_cache_at) > cls._ROLE_MAP_TTL:
+            out = {}
+            with closing(sqlite3.connect(cls.SETTINGS_DB)) as db:
+                for role_id, is_initial in db.execute("SELECT role_id, is_initial FROM admin_role").fetchall():
+                    aids = [int(r[0]) for r in db.execute(
+                        "SELECT alliances_id FROM adminserver_role WHERE role_id = ?", (role_id,)).fetchall()]
+                    tier = TIER_GLOBAL if is_initial else (TIER_ALLIANCE if aids else TIER_SERVER)
+                    out[int(role_id)] = (tier, aids)
+            cls._role_map_cache = out
+            cls._role_map_cache_at = now
+        return cls._role_map_cache
+
+    @staticmethod
+    def resolve_member_roles(role_ids: List[int]) -> dict:
+        """Resolve a member's Discord role ids to their effective role-only grant."""
+        role_map = PermissionManager._role_admin_map()
+        is_global = server = is_admin = False
+        alliance_ids = set()
+        for rid in role_ids:
+            grant = role_map.get(int(rid))
+            if not grant:
+                continue
+            is_admin = True
+            tier, aids = grant
+            if tier == TIER_GLOBAL:
+                is_global = True
+            elif tier == TIER_SERVER:
+                server = True
+            else:
+                alliance_ids.update(aids)
+        return {"is_admin": is_admin, "is_global": is_global, "server": server, "alliance_ids": sorted(alliance_ids)}
+
+    # Per-user cache of the resolved role grant, populated by the interaction boundary hook so `is_admin` et al. don't re-resolve roles every call.
+    _role_grant_by_user = {}   # {user_id: (RoleGrant, guild_id, expiry_monotonic)}
+    _ROLE_GRANT_TTL = 30.0
+
+    @classmethod
+    def cache_member_role_grant(cls, user_id: int, role_ids: List[int], guild_id: int | None = None) -> None:
+        grant = cls.resolve_member_roles(role_ids)
+        cls._role_grant_by_user[int(user_id)] = (grant, guild_id, time.monotonic() + cls._ROLE_GRANT_TTL)
+
+    @classmethod
+    def _cached_role_grant(cls, user_id: int) -> Optional[dict]:
+        entry = cls._role_grant_by_user.get(int(user_id))
+        if not entry:
+            return None
+        grant, guild_id, expiry = entry
+        if time.monotonic() > expiry:
+            cls._role_grant_by_user.pop(int(user_id), None)
+            return None
+        return {**grant, "guild_id": guild_id}
+
+    @staticmethod
+    def is_member_admin(user_id: int, role_ids: List[int]) -> Tuple[bool, bool]:
+        """Direct merge of a user's personal grant with their role grant, bypassing
+        the per-user cache. For the message-path site that has roles inline."""
+        admin_map = PermissionManager._admin_map()
+        user_admin = user_id in admin_map
+        user_global = user_admin and admin_map[user_id] == 1
+        rg = PermissionManager.resolve_member_roles(role_ids)
+        return (user_admin or rg["is_admin"], user_global or rg["is_global"])
+
+    @classmethod
+    def _bust_role_cache(cls):
+        cls._role_map_cache = None
+        cls._role_grant_by_user.clear()

--- a/main.py
+++ b/main.py
@@ -1440,6 +1440,18 @@ if __name__ == "__main__":
             conn_settings.execute("""CREATE INDEX IF NOT EXISTS idx_permission_audit_timestamp
                 ON permission_audit_log(timestamp DESC)""")
 
+            # Role-based admin grants: a Discord role holding a tier, mirroring admin/adminserver.
+            conn_settings.execute("""CREATE TABLE IF NOT EXISTS admin_role (
+                role_id     INTEGER PRIMARY KEY,
+                guild_id    INTEGER,
+                is_initial  INTEGER NOT NULL DEFAULT 0
+            )""")
+            conn_settings.execute("""CREATE TABLE IF NOT EXISTS adminserver_role (
+                role_id      INTEGER NOT NULL,
+                alliances_id INTEGER NOT NULL,
+                PRIMARY KEY (role_id, alliances_id)
+            )""")
+
             # Per-alliance opt-in channel summary posted after each redemption.
             # No row = disabled (default). Buckets choose what the summary lists.
             conn_settings.execute("""CREATE TABLE IF NOT EXISTS redemption_summary_settings (

--- a/tests/test_permission_role_grants.py
+++ b/tests/test_permission_role_grants.py
@@ -1,0 +1,135 @@
+import importlib, sqlite3
+import pytest
+
+pm_mod = importlib.import_module("cogs.permission_handler")
+PermissionManager = pm_mod.PermissionManager
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    db = tmp_path / "settings.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE admin (id INTEGER PRIMARY KEY, is_initial INTEGER, is_owner INTEGER)")
+        conn.execute("CREATE TABLE adminserver (admin INTEGER, alliances_id INTEGER)")
+        conn.execute("CREATE TABLE admin_role (role_id INTEGER PRIMARY KEY, guild_id INTEGER, is_initial INTEGER NOT NULL DEFAULT 0)")
+        conn.execute("CREATE TABLE adminserver_role (role_id INTEGER, alliances_id INTEGER, PRIMARY KEY (role_id, alliances_id))")
+        conn.commit()
+    monkeypatch.setattr(PermissionManager, "SETTINGS_DB", str(db))
+    return db
+
+
+def test_add_and_derive_role_tiers(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(111, 900, tier="global")
+    PermissionManager.add_role_grant(222, 900, tier="server")
+    PermissionManager.add_role_grant(333, 900, tier="alliance", alliance_ids=[5, 6])
+    assert PermissionManager.get_role_tier(111) == "global"
+    assert PermissionManager.get_role_tier(222) == "server"
+    assert PermissionManager.get_role_tier(333) == "alliance"
+    assert PermissionManager.get_role_tier(999) == "none"
+    assert sorted(PermissionManager.get_role_alliance_assignments(333)) == [5, 6]
+
+
+def test_role_grant_rejects_owner_and_empty_alliance(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    with pytest.raises(ValueError):
+        PermissionManager.add_role_grant(111, 900, tier="owner")
+    with pytest.raises(ValueError):
+        PermissionManager.add_role_grant(111, 900, tier="alliance", alliance_ids=[])
+
+
+def test_set_tier_replaces_scope_and_remove(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(333, 900, tier="alliance", alliance_ids=[5])
+    PermissionManager.set_role_tier(333, "alliance", alliance_ids=[7, 8])
+    assert sorted(PermissionManager.get_role_alliance_assignments(333)) == [7, 8]
+    PermissionManager.set_role_tier(333, "global")
+    assert PermissionManager.get_role_tier(333) == "global"
+    assert PermissionManager.get_role_alliance_assignments(333) == []
+    PermissionManager.remove_role_grant(333)
+    assert PermissionManager.get_role_tier(333) == "none"
+
+
+def test_resolve_member_roles_broadest_and_union(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(10, 900, tier="alliance", alliance_ids=[1])
+    PermissionManager.add_role_grant(20, 900, tier="alliance", alliance_ids=[2, 3])
+    PermissionManager._bust_role_cache()
+    g = PermissionManager.resolve_member_roles([10, 20, 99])  # 99 not granted
+    assert g["is_admin"] and not g["is_global"] and not g["server"]
+    assert sorted(g["alliance_ids"]) == [1, 2, 3]
+
+    PermissionManager.add_role_grant(30, 900, tier="global")
+    PermissionManager._bust_role_cache()
+    g2 = PermissionManager.resolve_member_roles([10, 30])
+    assert g2["is_admin"] and g2["is_global"]
+
+def test_resolve_member_roles_none(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    g = PermissionManager.resolve_member_roles([1, 2, 3])
+    assert g == {"is_admin": False, "is_global": False, "server": False, "alliance_ids": []}
+
+
+def _seed_user(db_path, uid, is_initial=0, is_owner=0, alliances=()):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT OR REPLACE INTO admin (id, is_initial, is_owner) VALUES (?, ?, ?)", (uid, is_initial, is_owner))
+        for aid in alliances:
+            conn.execute("INSERT INTO adminserver (admin, alliances_id) VALUES (?, ?)", (uid, aid))
+        conn.commit()
+
+def test_role_only_member_is_admin(tmp_path, monkeypatch):
+    db = _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(10, 900, tier="alliance", alliance_ids=[1])
+    PermissionManager._bust_role_cache()
+    PermissionManager._admin_cache = None  # bust user cache
+    # user 42 has no personal grant, but holds role 10
+    PermissionManager.cache_member_role_grant(42, [10], 900)
+    is_admin, is_global = PermissionManager.is_admin(42)
+    assert is_admin and not is_global
+    ids, glob = PermissionManager.get_admin_alliance_ids(42, guild_id=900)
+    assert glob is False and ids == [1]
+
+def test_user_and_role_union(tmp_path, monkeypatch):
+    db = _fresh_db(tmp_path, monkeypatch)
+    _seed_user(db, 42, is_initial=0, alliances=[1])   # Alliance Admin for 1
+    PermissionManager.add_role_grant(10, 900, tier="alliance", alliance_ids=[2])
+    PermissionManager._bust_role_cache(); PermissionManager._admin_cache = None
+    PermissionManager.cache_member_role_grant(42, [10], 900)
+    ids, glob = PermissionManager.get_admin_alliance_ids(42, guild_id=900)
+    assert glob is False and sorted(ids) == [1, 2]
+
+def test_role_global_beats_user_alliance(tmp_path, monkeypatch):
+    db = _fresh_db(tmp_path, monkeypatch)
+    _seed_user(db, 42, is_initial=0, alliances=[1])
+    PermissionManager.add_role_grant(10, 900, tier="global")
+    PermissionManager._bust_role_cache(); PermissionManager._admin_cache = None
+    PermissionManager.cache_member_role_grant(42, [10], 900)
+    is_admin, is_global = PermissionManager.is_admin(42)
+    assert is_admin and is_global
+    ids, glob = PermissionManager.get_admin_alliance_ids(42, guild_id=900)
+    assert glob is True and ids == []
+
+def test_is_member_admin_direct(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(10, 900, tier="server")
+    PermissionManager._bust_role_cache(); PermissionManager._admin_cache = None
+    assert PermissionManager.is_member_admin(77, [10]) == (True, False)
+    assert PermissionManager.is_member_admin(77, [999]) == (False, False)
+
+
+def test_role_admin_passes_upload_gate(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(10, 900, tier="alliance", alliance_ids=[1])
+    PermissionManager._bust_role_cache(); PermissionManager._admin_cache = None
+    # a member holding role 10 is recognized as admin at the message gate
+    ok, _ = PermissionManager.is_member_admin(555, [10])
+    assert ok is True
+
+
+def test_server_role_does_not_bleed_across_guilds(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    PermissionManager.add_role_grant(10, 900, tier="server")
+    PermissionManager._bust_role_cache(); PermissionManager._admin_cache = None
+    PermissionManager.cache_member_role_grant(42, [10], 900)   # earned in guild 900
+    # querying a DIFFERENT guild must NOT grant that guild's alliances
+    ids, glob = PermissionManager.get_admin_alliance_ids(42, guild_id=901)
+    assert glob is False and ids == []


### PR DESCRIPTION
Add role-based admin grants alongside per-user admins. Any tier except Owner can be granted to a Discord role via new admin_role/adminserver_role tables and a RoleSelect UI in the Permissions menu; every member holding the role inherits it. PermissionManager merges a member's role grant with their user grant (broadest tier wins, alliance scopes union), resolved
guild-scoped via an on_interaction cache, with the attendance-OCR upload gate resolving the member directly. Route the stragglers (minister_schedule, minister_menu, alliance_member_operations) through PermissionManager so role grants apply everywhere, dropping their ad-hoc admin-table checks. Document the combined rule in the Permissions embed.